### PR TITLE
ci: fix trivy scanning action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,15 @@ jobs:
         with:
           context: .
           load: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}:${{ github.sha }}
+      - name: Scan Docker image
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ github.repository }}:${{ github.sha }}
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          severity: 'CRITICAL'
       - name: Push Docker Image
         uses: docker/build-push-action@v2
         with:


### PR DESCRIPTION
Changes the build step to tag image with the commit SHA, which can be
uniquely referenced by the trivy scanning step. The push step takes that
same cached image and then pushes it to the registry with the correct
version tag(s).

This avoid the case where the metadata action creates multiple tags (e.g. on release with `v0.12.3` and `latest`) and trivy would try to scan both images, which is problematic since the CLI only supports scanning one image at a time.