### PR TITLE
Add multi-arch build, remove untagged deletion action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,6 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      - name: Delete Untagged Docker Images
-        uses: camargo/delete-untagged-action@v1
-        with:
-          github-token: ${{ secrets.DELETE_PACKAGES_TOKEN }}


### PR DESCRIPTION
Restores multi-arch image builds in the CI pipeline. Removes the `delete-untagged-action` that was removing untagged container images referenced in the multi-arch manifest.