### PR TITLE
Remove playground dependency and routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "cors": "^2.8.5",
         "express": "^4.18.1",
         "express-rate-limit": "^6.6.0",
-        "graphql-playground-middleware-express": "^1.7.23",
         "helmet": "^6.0.0",
         "multer": "^1.4.5-lts.1",
         "nanoid": "^4.0.0",
@@ -812,7 +811,8 @@
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "optional": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -895,11 +895,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/cssfilter": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
-      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.0",
@@ -1615,25 +1610,6 @@
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
-    },
-    "node_modules/graphql-playground-html": {
-      "version": "1.6.30",
-      "resolved": "https://registry.npmjs.org/graphql-playground-html/-/graphql-playground-html-1.6.30.tgz",
-      "integrity": "sha512-tpCujhsJMva4aqE8ULnF7/l3xw4sNRZcSHu+R00VV+W0mfp+Q20Plvcrp+5UXD+2yS6oyCXncA+zoQJQqhGCEw==",
-      "dependencies": {
-        "xss": "^1.0.6"
-      }
-    },
-    "node_modules/graphql-playground-middleware-express": {
-      "version": "1.7.23",
-      "resolved": "https://registry.npmjs.org/graphql-playground-middleware-express/-/graphql-playground-middleware-express-1.7.23.tgz",
-      "integrity": "sha512-M/zbTyC1rkgiQjFSgmzAv6umMHOphYLNWZp6Ye5QrD77WfGOOoSqDsVmGUczc2pDkEPEzzGB/bvBO5rdzaTRgw==",
-      "dependencies": {
-        "graphql-playground-html": "^1.6.30"
-      },
-      "peerDependencies": {
-        "express": "^4.16.2"
-      }
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -3129,21 +3105,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
-    "node_modules/xss": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.14.tgz",
-      "integrity": "sha512-og7TEJhXvn1a7kzZGQ7ETjdQVS2UfZyTlsEdDOqvQF7GoxNfY+0YLCzBy1kPdsDDx4QuNAonQPddpsn6Xl/7sw==",
-      "dependencies": {
-        "commander": "^2.20.3",
-        "cssfilter": "0.0.10"
-      },
-      "bin": {
-        "xss": "bin/xss"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -3795,7 +3756,8 @@
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "optional": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -3860,11 +3822,6 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
-    },
-    "cssfilter": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
-      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="
     },
     "data-uri-to-buffer": {
       "version": "4.0.0",
@@ -4414,22 +4371,6 @@
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
-    },
-    "graphql-playground-html": {
-      "version": "1.6.30",
-      "resolved": "https://registry.npmjs.org/graphql-playground-html/-/graphql-playground-html-1.6.30.tgz",
-      "integrity": "sha512-tpCujhsJMva4aqE8ULnF7/l3xw4sNRZcSHu+R00VV+W0mfp+Q20Plvcrp+5UXD+2yS6oyCXncA+zoQJQqhGCEw==",
-      "requires": {
-        "xss": "^1.0.6"
-      }
-    },
-    "graphql-playground-middleware-express": {
-      "version": "1.7.23",
-      "resolved": "https://registry.npmjs.org/graphql-playground-middleware-express/-/graphql-playground-middleware-express-1.7.23.tgz",
-      "integrity": "sha512-M/zbTyC1rkgiQjFSgmzAv6umMHOphYLNWZp6Ye5QrD77WfGOOoSqDsVmGUczc2pDkEPEzzGB/bvBO5rdzaTRgw==",
-      "requires": {
-        "graphql-playground-html": "^1.6.30"
-      }
     },
     "has": {
       "version": "1.0.3",
@@ -5504,15 +5445,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-    },
-    "xss": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.14.tgz",
-      "integrity": "sha512-og7TEJhXvn1a7kzZGQ7ETjdQVS2UfZyTlsEdDOqvQF7GoxNfY+0YLCzBy1kPdsDDx4QuNAonQPddpsn6Xl/7sw==",
-      "requires": {
-        "commander": "^2.20.3",
-        "cssfilter": "0.0.10"
-      }
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "cors": "^2.8.5",
     "express": "^4.18.1",
     "express-rate-limit": "^6.6.0",
-    "graphql-playground-middleware-express": "^1.7.23",
     "helmet": "^6.0.0",
     "multer": "^1.4.5-lts.1",
     "nanoid": "^4.0.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,6 @@ import initAuthRoutes from './packages/auth/routes.js';
 import { DbMerlin } from './packages/db/db.js';
 import initFileRoutes from './packages/files/files.js';
 import initHealthRoutes from './packages/health/health.js';
-import initPlaygroundRoutes from './packages/playground/playground.js';
 import initSwaggerRoutes from './packages/swagger/swagger.js';
 
 async function main(): Promise<void> {
@@ -24,7 +23,6 @@ async function main(): Promise<void> {
   initAuthRoutes(app);
   initFileRoutes(app);
   initHealthRoutes(app);
-  initPlaygroundRoutes(app);
   initSwaggerRoutes(app);
 
   app.listen(PORT, () => {

--- a/src/packages/playground/playground.ts
+++ b/src/packages/playground/playground.ts
@@ -1,9 +1,0 @@
-import type { Express } from 'express';
-import expressPlayground from 'graphql-playground-middleware-express';
-import { getEnv } from '../../env.js';
-
-export default (app: Express) => {
-  const { GQL_API_URL: endpoint } = getEnv();
-  const initPlayground = (expressPlayground as any).default;
-  app.get('/playground', initPlayground({ endpoint }));
-};


### PR DESCRIPTION
* The Playground is incompatible with our GraphQL schema (fails to load)
* New recommendation is to just use Hasura console
* If users need a more locked down playground they can look into deploying https://altairgraphql.dev/ or https://github.com/graphql/graphiql/tree/main/packages/graphiql
