### PR TITLE
Get user roles from database for use in JWT

### DIFF
--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -4,8 +4,12 @@ This document provides detailed information about environment variables for the 
 
 | Name                        | Description                                                              | Type     | Default                                        |
 | --------------------------- | ------------------------------------------------------------------------ | -------- | ---------------------------------------------- |
+| `ALLOWED_ROLES`             | Allowed roles when authentication is enabled.                            | `array`  | ["user", "viewer"]                             |
+| `ALLOWED_ROLES_NO_AUTH`     | Allowed roles when authentication is disabled.                           | `array`  | ["admin", "user", "viewer"]                    |
 | `AUTH_TYPE`                 | Mode of authentication. Set to `cam` to enable CAM authentication.       | `string` | none                                           |
 | `AUTH_URL`                  | URL of CAM REST API. Used if the given `AUTH_TYPE` is set to `cam`.      | `string` | https://atb-ocio-12b.jpl.nasa.gov:8443/cam-api |
+| `DEFAULT_ROLE`              | Default role when authentication is enabled.                             | `array`  | user                                           |
+| `DEFAULT_ROLE_NO_AUTH`      | Default role when authentication is disabled.                            | `array`  | admin                                          |
 | `GQL_API_URL`               | URL of GraphQL API for the GraphQL Playground.                           | `string` | http://localhost:8080/v1/graphql               |
 | `GQL_API_WS_URL`            | URL of GraphQL WebSocket API for the GraphQL Playground.                 | `string` | ws://localhost:8080/v1/graphql                 |
 | `HASURA_GRAPHQL_JWT_SECRET` | The JWT secret. Also in Hasura. **Required** even if auth off in Hasura. | `string` |                                                |

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,6 +1,10 @@
 export type Env = {
+  ALLOWED_ROLES: string[];
+  ALLOWED_ROLES_NO_AUTH: string[];
   AUTH_TYPE: string;
   AUTH_URL: string;
+  DEFAULT_ROLE: string;
+  DEFAULT_ROLE_NO_AUTH: string;
   GQL_API_URL: string;
   GQL_API_WS_URL: string;
   HASURA_GRAPHQL_JWT_SECRET: string;
@@ -18,8 +22,12 @@ export type Env = {
 };
 
 export const defaultEnv: Env = {
+  ALLOWED_ROLES: ['user', 'viewer'],
+  ALLOWED_ROLES_NO_AUTH: ['admin', 'user', 'viewer'],
   AUTH_TYPE: 'cam',
   AUTH_URL: 'https://atb-ocio-12b.jpl.nasa.gov:8443/cam-api',
+  DEFAULT_ROLE: 'user',
+  DEFAULT_ROLE_NO_AUTH: 'admin',
   GQL_API_URL: 'http://localhost:8080/v1/graphql',
   GQL_API_WS_URL: 'ws://localhost:8080/v1/graphql',
   HASURA_GRAPHQL_JWT_SECRET: '',
@@ -35,6 +43,22 @@ export const defaultEnv: Env = {
   RATE_LIMITER_LOGIN_MAX: 1000,
   VERSION: '1.9.0',
 };
+
+/**
+ * Parse string typed environment variable into an array.
+ * Returns the default value if parse fails.
+ */
+function parseArray(value: string | undefined, defaultValue: string[]): string[] {
+  if (typeof value === 'string') {
+    try {
+      const parsedValue = JSON.parse(value);
+      return parsedValue;
+    } catch {
+      return defaultValue;
+    }
+  }
+  return defaultValue;
+}
 
 /**
  * Parse string typed environment variable into a number.
@@ -53,8 +77,12 @@ function parseNumber(value: string | undefined, defaultValue: number): number {
 export function getEnv(): Env {
   const { env } = process;
 
+  const ALLOWED_ROLES = parseArray(env['ALLOWED_ROLES'], defaultEnv.ALLOWED_ROLES);
+  const ALLOWED_ROLES_NO_AUTH = parseArray(env['ALLOWED_ROLES_NO_AUTH'], defaultEnv.ALLOWED_ROLES_NO_AUTH);
   const AUTH_TYPE = env['AUTH_TYPE'] ?? defaultEnv.AUTH_TYPE;
   const AUTH_URL = env['AUTH_URL'] ?? defaultEnv.AUTH_URL;
+  const DEFAULT_ROLE = env['DEFAULT_ROLE'] ?? defaultEnv.DEFAULT_ROLE;
+  const DEFAULT_ROLE_NO_AUTH = env['DEFAULT_ROLE_NO_AUTH'] ?? defaultEnv.DEFAULT_ROLE_NO_AUTH;
   const GQL_API_URL = env['GQL_API_URL'] ?? defaultEnv.GQL_API_URL;
   const GQL_API_WS_URL = env['GQL_API_WS_URL'] ?? defaultEnv.GQL_API_WS_URL;
   const HASURA_GRAPHQL_JWT_SECRET = env['HASURA_GRAPHQL_JWT_SECRET'] ?? defaultEnv.HASURA_GRAPHQL_JWT_SECRET;
@@ -71,8 +99,12 @@ export function getEnv(): Env {
   const VERSION = env['npm_package_version'] ?? defaultEnv.VERSION;
 
   return {
+    ALLOWED_ROLES,
+    ALLOWED_ROLES_NO_AUTH,
     AUTH_TYPE,
     AUTH_URL,
+    DEFAULT_ROLE,
+    DEFAULT_ROLE_NO_AUTH,
     GQL_API_URL,
     GQL_API_WS_URL,
     HASURA_GRAPHQL_JWT_SECRET,

--- a/src/packages/auth/functions.ts
+++ b/src/packages/auth/functions.ts
@@ -3,11 +3,12 @@ import type { Response } from 'node-fetch';
 import fetch from 'node-fetch';
 import { getEnv } from '../../env.js';
 import getLogger from '../../logger.js';
+import { DbMerlin } from '../db/db.js';
 import type {
+  AuthResponse,
   JsonWebToken,
   JwtPayload,
   JwtSecret,
-  AuthResponse,
   LogoutResponse,
   SessionResponse,
   UserResponse,
@@ -25,6 +26,53 @@ export function authorizationHeaderToToken(authorizationHeader: string | undefin
     }
   } else {
     throw new Error(`Authorization header not found`);
+  }
+}
+
+/**
+ * Returns default role, and allowed roles for a user.
+ * If the user does not exist, this function creates the user and gives them a default role.
+ */
+export async function getUserRoles(
+  username: string,
+  default_role: string,
+  allowed_roles: string[],
+): Promise<{ allowed_roles: string[]; default_role: string }> {
+  const db = DbMerlin.getDb();
+
+  const { rows, rowCount } = await db.query(
+    `
+      select hasura_default_role, hasura_allowed_roles
+      from metadata.users_and_roles
+      where username = $1;
+    `,
+    [username],
+  );
+
+  if (rowCount > 0) {
+    const [row] = rows;
+    const { hasura_allowed_roles, hasura_default_role } = row;
+    return { allowed_roles: hasura_allowed_roles, default_role: hasura_default_role };
+  } else {
+    await db.query(
+      `
+        insert into metadata.users (username, default_role)
+        values ($1, $2);
+      `,
+      [username, default_role],
+    );
+
+    for (const allowed_role of allowed_roles) {
+      await db.query(
+        `
+          insert into metadata.users_allowed_roles (username, allowed_role)
+          values ($1, $2);
+        `,
+        [username, allowed_role],
+      );
+    }
+
+    return { allowed_roles, default_role };
   }
 }
 
@@ -74,7 +122,7 @@ export function generateJwt(
 }
 
 export async function login(username: string, password: string): Promise<AuthResponse> {
-  const { AUTH_TYPE, AUTH_URL } = getEnv();
+  const { AUTH_TYPE, AUTH_URL, ALLOWED_ROLES, ALLOWED_ROLES_NO_AUTH, DEFAULT_ROLE, DEFAULT_ROLE_NO_AUTH } = getEnv();
 
   if (AUTH_TYPE === 'cam') {
     let response: Response | undefined;
@@ -96,11 +144,11 @@ export async function login(username: string, password: string): Promise<AuthRes
         };
       } else {
         const { ssoCookieValue: camToken } = json;
-        // TODO: Use other roles instead of 'admin'.
+        const { allowed_roles, default_role } = await getUserRoles(username, DEFAULT_ROLE, ALLOWED_ROLES);
         return {
           message: 'Login successful',
           success: true,
-          token: generateJwt(username, camToken, 'admin', ['admin', 'user']),
+          token: generateJwt(username, camToken, default_role, allowed_roles),
         };
       }
     } catch (error) {
@@ -114,10 +162,11 @@ export async function login(username: string, password: string): Promise<AuthRes
       };
     }
   } else {
+    const { allowed_roles, default_role } = await getUserRoles(username, DEFAULT_ROLE_NO_AUTH, ALLOWED_ROLES_NO_AUTH);
     return {
       message: 'Authentication is disabled',
       success: true,
-      token: generateJwt(username || 'unknown', '', 'admin', ['admin', 'user']),
+      token: generateJwt(username, '', default_role, allowed_roles),
     };
   }
 }


### PR DESCRIPTION
Resolves https://github.com/NASA-AMMOS/aerie/issues/862

* Queries for user roles in DB and sets them in JWT
* Creates user in DB if they do not exist and assigns them default 'user' role

## TODO

- [x] Update the queries in this commit with the real table name and columns that are added in https://github.com/NASA-AMMOS/aerie/issues/938