### PR TITLE
Add route that regenerates token with active role encoded

### DIFF
--- a/src/packages/auth/routes.ts
+++ b/src/packages/auth/routes.ts
@@ -1,7 +1,7 @@
 import type { Express } from 'express';
 import rateLimit from 'express-rate-limit';
 import { getEnv } from '../../env.js';
-import { login, logout, session, user } from './functions.js';
+import { changeRole, login, logout, session, user } from './functions.js';
 
 export default (app: Express) => {
   const { RATE_LIMITER_LOGIN_MAX } = getEnv();
@@ -35,7 +35,7 @@ export default (app: Express) => {
    *                 type: string
    *     responses:
    *       200:
-   *         description: LoginResponse
+   *         description: AuthResponse
    *     summary: Login to initiate a session
    *     tags:
    *       - Auth
@@ -107,6 +107,41 @@ export default (app: Express) => {
   app.get('/auth/user', async (req, res) => {
     const authorizationHeader = req.get('authorization');
     const response = await user(authorizationHeader);
+    res.json(response);
+  });
+
+  /**
+   * @swagger
+   * /auth/changeRole:
+   *   post:
+   *     security:
+   *       - bearerAuth: []
+   *     consumes:
+   *       - application/json
+   *     produces:
+   *       - application/json
+   *     requestBody:
+   *       description: User's desired role
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             properties:
+   *               role:
+   *                 type: string
+   *     responses:
+   *       200:
+   *         description: AuthResponse
+   *     summary: Changes a user's role in the session
+   *     tags:
+   *       - Auth
+   */
+  app.post('/auth/changeRole', async (req, res) => {
+    const authorizationHeader = req.get('authorization');
+    const { body } = req;
+    const { role: requestedRole } = body;
+    const response = await changeRole(authorizationHeader, requestedRole);
     res.json(response);
   });
 };

--- a/src/packages/auth/types.ts
+++ b/src/packages/auth/types.ts
@@ -1,6 +1,7 @@
 export type JsonWebToken = string;
 
 export type JwtPayload = {
+  activeRole: string;
   camToken: string;
   'https://hasura.io/jwt/claims': Record<string, string | string[]>;
   username: string;
@@ -11,7 +12,7 @@ export type JwtSecret = {
   type: string;
 };
 
-export type LoginResponse = {
+export type AuthResponse = {
   message: string;
   success: boolean;
   token: JsonWebToken | null;


### PR DESCRIPTION
This is required for https://github.com/NASA-AMMOS/aerie-ui/issues/690

* Adds a new `activeRole` key to the token. The intent is to keep user related information as centralized as possible and as a side-effect, provides a form of persistence for the session.
* Adds a new route `changeRole` that encodes the desired role into a new token
