### PR TITLE
Remove change role endpoint

### DIFF
--- a/src/packages/auth/routes.ts
+++ b/src/packages/auth/routes.ts
@@ -1,7 +1,7 @@
 import type { Express } from 'express';
 import rateLimit from 'express-rate-limit';
 import { getEnv } from '../../env.js';
-import { changeRole, login, session } from './functions.js';
+import { login, session } from './functions.js';
 
 export default (app: Express) => {
   const { RATE_LIMITER_LOGIN_MAX } = getEnv();
@@ -65,41 +65,6 @@ export default (app: Express) => {
   app.get('/auth/session', async (req, res) => {
     const authorizationHeader = req.get('authorization');
     const response = await session(authorizationHeader);
-    res.json(response);
-  });
-
-  /**
-   * @swagger
-   * /auth/changeRole:
-   *   post:
-   *     security:
-   *       - bearerAuth: []
-   *     consumes:
-   *       - application/json
-   *     produces:
-   *       - application/json
-   *     requestBody:
-   *       description: User's desired role
-   *       required: true
-   *       content:
-   *         application/json:
-   *           schema:
-   *             type: object
-   *             properties:
-   *               role:
-   *                 type: string
-   *     responses:
-   *       200:
-   *         description: AuthResponse
-   *     summary: Changes a user's role in the session
-   *     tags:
-   *       - Auth
-   */
-  app.post('/auth/changeRole', async (req, res) => {
-    const authorizationHeader = req.get('authorization');
-    const { body } = req;
-    const { role: requestedRole } = body;
-    const response = await changeRole(authorizationHeader, requestedRole);
     res.json(response);
   });
 };

--- a/src/packages/auth/types.ts
+++ b/src/packages/auth/types.ts
@@ -6,7 +6,6 @@ export type JwtDecode = {
 };
 
 export type JwtPayload = {
-  activeRole: string;
   'https://hasura.io/jwt/claims': Record<string, string | string[]>;
   username: string;
 };


### PR DESCRIPTION
* It is not needed in the token. The role can be se via the `x-hasura-role` header.
* Also remove the active role from the token since this makes it obsolete.
* UI PR: https://github.com/NASA-AMMOS/aerie-ui/pull/891
* Closes https://github.com/NASA-AMMOS/aerie/issues/1129