### PR TITLE
Improve altair experience

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,4 +1,5 @@
 module.exports = {
+  ignorePatterns: ["static/*"],
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
-        "altair-express-middleware": "^5.0.28",
+        "altair-express-middleware": "^5.2.11",
         "cors": "^2.8.5",
         "express": "^4.18.2",
         "express-rate-limit": "^6.7.0",
@@ -637,11 +637,11 @@
       }
     },
     "node_modules/altair-express-middleware": {
-      "version": "5.0.28",
-      "resolved": "https://registry.npmjs.org/altair-express-middleware/-/altair-express-middleware-5.0.28.tgz",
-      "integrity": "sha512-qoqlGxWrrAXZ6Iuz7msbWofkeO9fSS0PXwncLrUKlYUGjpX6Uv6FqTeTbkSXs+TGhjMjp0qsnrgFa3d0b807dA==",
+      "version": "5.2.11",
+      "resolved": "https://registry.npmjs.org/altair-express-middleware/-/altair-express-middleware-5.2.11.tgz",
+      "integrity": "sha512-ezZtpmTf+P36U7NhS1Gj2ziChTyXAN5EO4QKbQI+V21QNfKnNGMua/0Hw1B/TGsIgCRr7taBqa5akLApYFy1qA==",
       "dependencies": {
-        "altair-static": "^5.0.28",
+        "altair-static": "^5.2.11",
         "express": "^4.16.2"
       },
       "engines": {
@@ -653,9 +653,9 @@
       }
     },
     "node_modules/altair-static": {
-      "version": "5.0.28",
-      "resolved": "https://registry.npmjs.org/altair-static/-/altair-static-5.0.28.tgz",
-      "integrity": "sha512-RMThoxUODIEM1f9UqWO+hTemhbR8D6feMSW2fcnxHIciw901yckdxmfpseh2Z6H0S4COitZO4YXkFPrnzFxHVA==",
+      "version": "5.2.11",
+      "resolved": "https://registry.npmjs.org/altair-static/-/altair-static-5.2.11.tgz",
+      "integrity": "sha512-WByckcissWf6Drx87+L0dqe269PAMZngjMUHcR1oUVoM5NRFenO8RPH0+TSV8fuZXAXeiKgrYa5B67rjzd+kOA==",
       "engines": {
         "node": ">= 6.9.1"
       },
@@ -3816,18 +3816,18 @@
       }
     },
     "altair-express-middleware": {
-      "version": "5.0.28",
-      "resolved": "https://registry.npmjs.org/altair-express-middleware/-/altair-express-middleware-5.0.28.tgz",
-      "integrity": "sha512-qoqlGxWrrAXZ6Iuz7msbWofkeO9fSS0PXwncLrUKlYUGjpX6Uv6FqTeTbkSXs+TGhjMjp0qsnrgFa3d0b807dA==",
+      "version": "5.2.11",
+      "resolved": "https://registry.npmjs.org/altair-express-middleware/-/altair-express-middleware-5.2.11.tgz",
+      "integrity": "sha512-ezZtpmTf+P36U7NhS1Gj2ziChTyXAN5EO4QKbQI+V21QNfKnNGMua/0Hw1B/TGsIgCRr7taBqa5akLApYFy1qA==",
       "requires": {
-        "altair-static": "^5.0.28",
+        "altair-static": "^5.2.11",
         "express": "^4.16.2"
       }
     },
     "altair-static": {
-      "version": "5.0.28",
-      "resolved": "https://registry.npmjs.org/altair-static/-/altair-static-5.0.28.tgz",
-      "integrity": "sha512-RMThoxUODIEM1f9UqWO+hTemhbR8D6feMSW2fcnxHIciw901yckdxmfpseh2Z6H0S4COitZO4YXkFPrnzFxHVA=="
+      "version": "5.2.11",
+      "resolved": "https://registry.npmjs.org/altair-static/-/altair-static-5.2.11.tgz",
+      "integrity": "sha512-WByckcissWf6Drx87+L0dqe269PAMZngjMUHcR1oUVoM5NRFenO8RPH0+TSV8fuZXAXeiKgrYa5B67rjzd+kOA=="
     },
     "ansi-regex": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "start": "node dist/main.js"
   },
   "dependencies": {
-    "altair-express-middleware": "^5.0.28",
+    "altair-express-middleware": "^5.2.11",
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "express-rate-limit": "^6.7.0",

--- a/src/packages/api-playground/api-playground.ts
+++ b/src/packages/api-playground/api-playground.ts
@@ -1,27 +1,13 @@
 import { altairExpress } from 'altair-express-middleware';
 import type { Express } from 'express';
 import { getEnv } from '../../env.js';
+import { readFileSync } from 'fs';
 
 export default (app: Express) => {
   const { GQL_API_URL: endpointURL, GQL_API_WS_URL: subscriptionsEndpoint } = getEnv();
   const initialQuery = '{ plan { id name } }';
   const initialHeaders = { Authorization: 'Bearer {{user}}', 'x-hasura-role': 'viewer' };
-  const initialPreRequestScript =
-  `
-  // Fetch a new token from the Gateway
-  const res = await altair.helpers.request(
-    'POST',
-    '/auth/login', // AUTH ENDPOINT OF THE DEPLOYMENT
-  {
-    body: { "username": "<YOUR_AERIE_USERNAME>", "password": "<YOUR_AERIE_PASSWORD>"}, // CREDENTIALS TO LOG IN AS
-    headers: {"Content-Type": "application/json"}
-  });
-  if(res.success) {
-    const token = res.token;
-    await altair.helpers.setEnvironment("user", token);
-  } else {
-    altair.log(res);
-  }`;
+  const initialPreRequestScript = readFileSync('static/api-playground/pre-request-script.js').toString();
   const initialSettings = {
     addQueryDepthLimit: 5,
     enableExperimental: true,

--- a/src/packages/api-playground/api-playground.ts
+++ b/src/packages/api-playground/api-playground.ts
@@ -5,5 +5,44 @@ import { getEnv } from '../../env.js';
 export default (app: Express) => {
   const { GQL_API_URL: endpointURL, GQL_API_WS_URL: subscriptionsEndpoint } = getEnv();
   const initialQuery = '{ plan { id name } }';
-  app.use('/api-playground', altairExpress({ endpointURL, initialQuery, subscriptionsEndpoint }));
+  const initialHeaders = { Authorization: 'Bearer {{user}}', 'x-hasura-role': 'viewer' };
+  const initialPreRequestScript =
+  `
+  // Fetch a new token from the Gateway
+  const res = await altair.helpers.request(
+    'POST',
+    '/auth/login', // AUTH ENDPOINT OF THE DEPLOYMENT
+  {
+    body: { "username": "<YOUR_AERIE_USERNAME>", "password": "<YOUR_AERIE_PASSWORD>"}, // CREDENTIALS TO LOG IN AS
+    headers: {"Content-Type": "application/json"}
+  });
+  if(res.success) {
+    const token = res.token;
+    await altair.helpers.setEnvironment("user", token);
+  } else {
+    altair.log(res);
+  }`;
+  const initialSettings = {
+    addQueryDepthLimit: 5,
+    enableExperimental: true,
+    'plugin.list': ['altair-graphql-plugin-graphql-explorer'],
+    'request.withCredentials': true,
+    'schema.reloadOnStart': true,
+    'script.allowedCookies': ['user'],
+    tabSize: 2,
+    theme: 'dracula',
+  };
+
+  app.use(
+    '/api-playground',
+    altairExpress({
+      disableAccount: true,
+      endpointURL,
+      initialHeaders,
+      initialPreRequestScript,
+      initialQuery,
+      initialSettings,
+      subscriptionsEndpoint,
+    }),
+  );
 };

--- a/static/api-playground/pre-request-script.js
+++ b/static/api-playground/pre-request-script.js
@@ -1,0 +1,24 @@
+const nowInSeconds = () => Date.now() / 1000;
+const tokenExpiry = await altair.storage.get('token_exp') || 0;
+
+if (nowInSeconds() >= Number(tokenExpiry)) {
+  // Fetch a new token from the Gateway
+  const res = await altair.helpers.request(
+    'POST',
+    '/auth/login', // AUTH ENDPOINT OF THE DEPLOYMENT
+    {
+      body: { username: '<YOUR_AERIE_USERNAME>', password: '<YOUR_AERIE_PASSWORD>' }, // CREDENTIALS TO LOG IN AS
+      headers: { 'Content-Type': 'application/json' }
+    });
+  if(res.success) {
+    const token = res.token;
+    await altair.storage.set('token', token);
+    // Set JWT expiry
+    const atob = await altair.importModule('atob');
+    const body = JSON.parse(atob(token.split('.')[1]));
+    await altair.storage.set('token_exp', body.exp);
+  } else { altair.log(res); }
+}
+// Set the token in the environment
+const token = await altair.storage.get('token');
+altair.helpers.setEnvironment('user', token);


### PR DESCRIPTION
Partially address https://github.com/NASA-AMMOS/aerie/issues/1210.

1) Updates the version of Altair from 5.0.28 to 5.2.11 (the latest release). This is important, as the added prerequest script depends on commands added after 5.0.28.
2) Updates the launch configuration of Altair. Most importantly of these changes, it adds the GraphiQL Explorer plugin (the thing that appears on the right side of Hasura Qurery panel and allows for query building via clicking on entries), adds a prerequest script to sign the user in if their token is invalid/missing, and sets the `x-hasura-role: viewer` and `Authorization` header. It also sets the changes the default theme from `light` to `dracula`.

Instructions:
1) When visiting the API Playground for the first time, you will be prompted to install the `altair-graphql-plugin-graphql-explorer` plugin. Allow this.
2) When opening a new window, visit the `pre-request` tab and set your username/password.
3) Press the `Refresh Docs` icon directly to the left of the `Docs` button (two to the left of `Send Request`)
4) Open the Explorer panel via the symbol beneath the suitcase on the left sidebar

Your page should now look like this:

<img width="1728" alt="Screenshot 2023-11-22 at 9 00 18 AM" src="https://github.com/NASA-AMMOS/aerie-gateway/assets/62574120/be38579b-9fa9-448c-8d97-6ed1b5163662">


Things to note: 
- The script is currently stores its JWT under the `token` name instead of potentially clashing with the UI for `user`
- The script only checks if the JWT is expired. If you dump your database, you will need to temporarily remove the `await altair.storage.get("token_exp")` from the line `const tokenExpiry = await altair.storage.get("token_exp") || 0;` to force it to refresh
- In order to use plugins, Altair has to be in "dev mode"
- After updating your role, you need to refresh your docs to see changes in the explorer pane.

## Docs

The "How to Interact with the API Playground" docs will need to be updated. (Docs ticket [here](https://github.com/NASA-AMMOS/aerie-docs/issues/105))

## Future Work

- If a login service is added to this endpoint, similar to the UI, then the script can be updated to no longer require users to put their user-pass in the clear every time they open a new window. This means that users will have the correct headers automatically for the Explorer window.

- We may want to expose what the role set by default for the `x-hasura-role` header is via an environment variable. 