### PR TITLE
Update GH Actions to Use Node20 Versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: npm
@@ -34,20 +34,20 @@ jobs:
           rm -rf node_modules
           npm install --only=production
       - name: Login to the Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ github.token }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Extract Metadata (tags and labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}
       - name: Build Docker Image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           load: true
@@ -61,7 +61,7 @@ jobs:
           ignore-unfixed: true
           severity: 'CRITICAL'
       - name: Push Docker Image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           push: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,22 +28,22 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v3
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
       - name: NASA Scrub
         run: |
           pip install nasa-scrub
           python3 -m scrub.tools.parsers.translate_results /home/runner/work/aerie-gateway/results/*.sarif /home/runner/work/aerie-gateway/results/codeql.scrub ${{ github.workspace }} scrub
           python3 -m scrub.tools.parsers.csv_parser /home/runner/work/aerie-gateway/results
       - name: Upload CodeQL Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: codeql-artifacts
           path: /home/runner/work/aerie-gateway/results/*

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: lint
+name: Lint
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
       - develop
 
 jobs:
-  list:
+  lint:
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,9 +14,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: ci
+name: Publish
 
 on:
   push:
@@ -13,7 +13,7 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-  ci:
+  publish:
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: npm


### PR DESCRIPTION
Sister PR of https://github.com/NASA-AMMOS/aerie/pull/1339. 

Updates all actions to use their Node 20 versions. 

Additionally, rename the `ci` job to `Publish` to be consistent with our other repos.

Successful Workflow Runs for Verification:

- [x] [CodeQL](https://github.com/NASA-AMMOS/aerie-gateway/actions/runs/8012033156?pr=68)
- [x] [Test](https://github.com/NASA-AMMOS/aerie-gateway/actions/runs/8012033163?pr=68)
- [x] [Lint](https://github.com/NASA-AMMOS/aerie-gateway/actions/runs/8012033153?pr=68)
- [x] [Publish](https://github.com/NASA-AMMOS/aerie-gateway/actions/runs/8012075283?pr=68)