### PR TITLE
Add `/version` endpoint

### DIFF
--- a/src/packages/health/health.ts
+++ b/src/packages/health/health.ts
@@ -1,4 +1,5 @@
 import type { Express } from 'express';
+import { getEnv } from '../../env.js';
 
 export default (app: Express) => {
   /**
@@ -28,5 +29,31 @@ export default (app: Express) => {
     const timestamp = new Date().toISOString();
     const uptimeMinutes = process.uptime() / 60;
     res.json({ timestamp, uptimeMinutes });
+  });
+
+  /**
+   * @swagger
+   * /version:
+   *   get:
+   *     produces:
+   *       - application/json
+   *     responses:
+   *       200:
+   *         description: Version metrics
+   *         content:
+   *           application/json:
+   *             schema:
+   *                properties:
+   *                  gateway_version:
+   *                    description: The current version of the Aerie Gateway.
+   *                    type: string
+   *     summary: Get the current version of the Gateway and Database Schema
+   *     tags:
+   *       - Version
+   */
+  app.get('/version', async (_, res) => {
+    res.json({
+      version: getEnv().VERSION,
+    });
   });
 };


### PR DESCRIPTION
Partially addresses https://github.com/NASA-AMMOS/aerie/issues/1535

The `db_schema_version` part of the ticket will be added in a follow-up, as it requires a change in the DB permissions to allow the Gateway to query the necessary table.