### PR TITLE
GH workflow: Publish docker image when PR is labeled 'publish'

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,10 @@ on:
       - dev-[0-9]+.[0-9]+.[0-9]+
     tags:
       - v*
+  pull_request:
+    types:
+      # publish images for PRs labeled "publish" whenever changed/labeled
+      [ opened, reopened, synchronize, labeled ]
   workflow_dispatch:
 
 env:
@@ -14,6 +18,8 @@ env:
 
 jobs:
   publish:
+    # for PRs, should only publish if it has "publish" label
+    if: ${{ (github.event_name != 'pull_request') || contains(github.event.pull_request.labels.*.name, 'publish') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 files/*
 node_modules
 .env
+.idea/


### PR DESCRIPTION
Supporting this issue: https://github.com/NASA-AMMOS/aerie/issues/1538

This change will cause the GH "Publish" workflow to run whenever an `aerie-gateway` PR is given the "publish" label, which will cause a Docker image to be published from the PR branch, tagged with the PR number eg. `pr-107`

The published gateway PR can then be referenced in an `aerie-ui` PR with a flag in the PR body that looks like eg. `___REQUIRES_GATEWAY_PR___="107"`, which will cause the `aerie-ui` e2e tests to use the published `pr-107` gateway image during testing rather than the default `develop` branch.