### PR TITLE
Add healthcheck to gateway dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,11 @@
 FROM node:lts-alpine
+RUN apk add --no-cache curl
+
 COPY . /app
 WORKDIR /app
+
+# define health check for container: /health route will return 200 if healthy
+HEALTHCHECK --interval=2s --timeout=2s --start-period=2s --retries=15 \
+  CMD /bin/sh -c 'curl -sf http://localhost:$PORT/health || exit 1'
+
 CMD [ "npm", "start" ]


### PR DESCRIPTION
Adds a [**docker health check**](https://docs.docker.com/reference/dockerfile/#healthcheck) to the Gateway dockerfile. This lays some groundwork for future improvements by allowing Docker to know whether or not a container is actually "healthy", ie. **ready to be used**, instead of just running. In future we can use this in our docker compose to express dependencies and not allow services to start up until other services are ready.

Gateway already exposes a `/health` endpoint so this just hits it to determine service health.

**To test this**
1. checkout this branch
2. `docker build . -t aerie_gateway_test`
3. `docker run --rm -p 27187:27187 --env PORT=27187 aerie_gateway_test`
4. Open a separate terminal
5. `docker ps`, copy the ID of the `aerie_gateway_test` container
6. `docker inspect --format='{{.State.Health.Status}}' YOUR-CONTAINER-ID`
7. This should return `healthy`! (Or `starting`, but `healthy` after a few seconds).