### PR TITLE
Sequence Template Import

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { getEnv } from './env.js';
 import getLogger from './logger.js';
 import initApiPlaygroundRoutes from './packages/api-playground/api-playground.js';
 import initAuthRoutes from './packages/auth/routes.js';
+import initExpansionRoutes from './packages/expansion/expansion.js';
 import { DbMerlin } from './packages/db/db.js';
 import initFileRoutes from './packages/files/files.js';
 import initHasuraRoutes from './packages/hasura/hasura-events.js';
@@ -44,6 +45,7 @@ async function main(): Promise<void> {
 
   initApiPlaygroundRoutes(app);
   initAuthRoutes(app, authHandler);
+  initExpansionRoutes(app);
   initFileRoutes(app);
   initHealthRoutes(app);
   initHasuraRoutes(app);

--- a/src/packages/expansion/expansion.ts
+++ b/src/packages/expansion/expansion.ts
@@ -78,11 +78,10 @@ async function importSequenceTemplate(req: Request, res: Response) {
       throw Error('Sequence template creation unsuccessful.');
     }
     res.json(createdSequenceTemplate);
-  } catch (error) {
+  } catch (error: any) {
     logger.error(`POST /importSequenceTemplate: Error occurred during sequence template ${name} import`);
     logger.error(error);
-    res.status(500);
-    res.send((error as Error).message);
+    res.status(500).json({ message: error.message, success: false });
   }
 }
 

--- a/src/packages/expansion/expansion.ts
+++ b/src/packages/expansion/expansion.ts
@@ -1,0 +1,149 @@
+import type { Express, Request, Response } from 'express';
+import rateLimit from 'express-rate-limit';
+import multer from 'multer';
+import getLogger from '../../logger.js';
+import { auth } from '../auth/middleware.js';
+import { getEnv } from '../../env.js';
+import {
+  ImportSequenceTemplatePayload,
+  SequenceTemplateInsertInput,
+  SequenceTemplateSchema,
+} from '../../types/expansion.js';
+import gql from './gql.js';
+
+const upload = multer();
+const logger = getLogger('packages/plan/plan');
+const { RATE_LIMITER_LOGIN_MAX, HASURA_API_URL } = getEnv();
+
+const GQL_API_URL = `${HASURA_API_URL}/v1/graphql`;
+
+const refreshLimiter = rateLimit({
+  legacyHeaders: false,
+  max: RATE_LIMITER_LOGIN_MAX,
+  standardHeaders: true,
+  windowMs: 15 * 60 * 1000, // 15 minutes
+});
+
+async function importSequenceTemplate(req: Request, res: Response) {
+  const authorizationHeader = req.get('authorization');
+
+  const {
+    headers: { 'x-hasura-role': roleHeader, 'x-hasura-user-id': userHeader },
+  } = req;
+
+  const { body, file } = req;
+  const { activity_type, language, model_id, name, parcel_id } = body as ImportSequenceTemplatePayload;
+
+  logger.info(`POST /importSequenceTemplate: Importing sequence template: ${name}`);
+
+  const headers: HeadersInit = {
+    Authorization: authorizationHeader ?? '',
+    'Content-Type': 'application/json',
+    'x-hasura-role': roleHeader ? `${roleHeader}` : '',
+    'x-hasura-user-id': userHeader ? `${userHeader}` : '',
+  };
+
+  let createdSequenceTemplate: SequenceTemplateSchema | null = null;
+
+  try {
+    if (file === undefined) {
+      throw Error('No sequence template file was given in the request!');
+    }
+    const sequenceTemplateContent: string = file.buffer.toString();
+    logger.info(`POST /importSequenceTemplate: Creating sequence template: ${name}`);
+
+    const sequenceTemplateInsertInput: SequenceTemplateInsertInput = {
+      activity_type,
+      language,
+      model_id,
+      name,
+      parcel_id,
+      template_definition: sequenceTemplateContent,
+    };
+
+    // TODO: Add multi-import
+    const sequenceTemplateCreationResponse = await fetch(GQL_API_URL, {
+      body: JSON.stringify({
+        query: gql.CREATE_SEQUENCE_TEMPLATE,
+        variables: { sequenceTemplateInsertInput: [sequenceTemplateInsertInput] },
+      }),
+      headers,
+      method: 'POST',
+    });
+
+    const sequenceTemplateCreationResponseJSON = (await sequenceTemplateCreationResponse.json()) as {
+      data: {
+        insert_sequence_template: any;
+      };
+    };
+
+    if (sequenceTemplateCreationResponseJSON !== null && sequenceTemplateCreationResponseJSON.data !== null) {
+      createdSequenceTemplate = sequenceTemplateCreationResponseJSON.data.insert_sequence_template;
+      logger.info(`POST /importSequenceTemplate: Imported sequence template: ${name}`);
+    } else {
+      throw Error('Sequence template creation unsuccessful.');
+    }
+    res.json(createdSequenceTemplate);
+  } catch (error) {
+    logger.error(`POST /importSequenceTemplate: Error occurred during sequence template ${name} import`);
+    logger.error(error);
+    res.status(500);
+    res.send((error as Error).message);
+  }
+}
+
+export default (app: Express) => {
+  /**
+   * @swagger
+   * /importSequenceTemplate:
+   *   post:
+   *     security:
+   *       - bearerAuth: []
+   *     consumes:
+   *       - multipart/form-data
+   *     produces:
+   *       - application/json
+   *     parameters:
+   *      - in: header
+   *        name: x-hasura-role
+   *        schema:
+   *          type: string
+   *          required: false
+   *     requestBody:
+   *       content:
+   *         multipart/form-data:
+   *          schema:
+   *            type: object
+   *            properties:
+   *              sequence_template_file:
+   *                format: binary
+   *                type: string
+   *              activity_type:
+   *                type: string
+   *              language:
+   *                type: string
+   *              model_id:
+   *                type: integer
+   *              name:
+   *                type: string
+   *              parcel_id:
+   *                type: integer
+   *     responses:
+   *       200:
+   *         description: ImportResponse
+   *       403:
+   *         description: Unauthorized error
+   *       401:
+   *         description: Unauthenticated error
+   *     summary: Import a sequence template
+   *     tags:
+   *       - Hasura
+   */
+  app.post(
+    '/importSequenceTemplate',
+    upload.single('sequence_template_file'),
+    refreshLimiter,
+    auth,
+    importSequenceTemplate,
+  );
+};

--- a/src/packages/expansion/expansion.ts
+++ b/src/packages/expansion/expansion.ts
@@ -65,7 +65,7 @@ async function importSequenceTemplate(req: Request, res: Response) {
       method: 'POST',
     });
 
-    const responseJSON = (await sequenceTemplateCreationResponse.json());
+    const responseJSON = await sequenceTemplateCreationResponse.json();
 
     if (responseJSON && responseJSON?.errors && responseJSON.errors.length) {
       const [error] = responseJSON.errors;

--- a/src/packages/expansion/expansion.ts
+++ b/src/packages/expansion/expansion.ts
@@ -65,14 +65,13 @@ async function importSequenceTemplate(req: Request, res: Response) {
       method: 'POST',
     });
 
-    const sequenceTemplateCreationResponseJSON = (await sequenceTemplateCreationResponse.json()) as {
-      data: {
-        insert_sequence_template: any;
-      };
-    };
+    const responseJSON = (await sequenceTemplateCreationResponse.json());
 
-    if (sequenceTemplateCreationResponseJSON !== null && sequenceTemplateCreationResponseJSON.data !== null) {
-      createdSequenceTemplate = sequenceTemplateCreationResponseJSON.data.insert_sequence_template;
+    if (responseJSON && responseJSON?.errors && responseJSON.errors.length) {
+      const [error] = responseJSON.errors;
+      throw new Error(error?.message ?? JSON.stringify(error));
+    } else if (responseJSON !== null && responseJSON.data !== null) {
+      createdSequenceTemplate = responseJSON.data?.insert_sequence_template;
       logger.info(`POST /importSequenceTemplate: Imported sequence template: ${name}`);
     } else {
       throw Error('Sequence template creation unsuccessful.');

--- a/src/packages/expansion/expansion.ts
+++ b/src/packages/expansion/expansion.ts
@@ -1,6 +1,5 @@
 import type { Express, Request, Response } from 'express';
 import rateLimit from 'express-rate-limit';
-import multer from 'multer';
 import getLogger from '../../logger.js';
 import { auth } from '../auth/middleware.js';
 import { getEnv } from '../../env.js';
@@ -11,7 +10,6 @@ import {
 } from '../../types/expansion.js';
 import gql from './gql.js';
 
-const upload = multer();
 const logger = getLogger('packages/plan/plan');
 const { RATE_LIMITER_LOGIN_MAX, HASURA_API_URL } = getEnv();
 
@@ -31,7 +29,8 @@ async function importSequenceTemplate(req: Request, res: Response) {
     headers: { 'x-hasura-role': roleHeader, 'x-hasura-user-id': userHeader },
   } = req;
 
-  const { activity_type, language, model_id, name, parcel_id, sequence_template_file } = req.body as ImportSequenceTemplatePayload;
+  const { activity_type, language, model_id, name, parcel_id, sequence_template_file } =
+    req.body as ImportSequenceTemplatePayload;
 
   logger.info(`POST /importSequenceTemplate: Importing sequence template: ${name}`);
 
@@ -133,10 +132,5 @@ export default (app: Express) => {
    *     tags:
    *       - Hasura
    */
-  app.post(
-    '/importSequenceTemplate',
-    refreshLimiter,
-    auth,
-    importSequenceTemplate,
-  );
+  app.post('/importSequenceTemplate', refreshLimiter, auth, importSequenceTemplate);
 };

--- a/src/packages/expansion/expansion.ts
+++ b/src/packages/expansion/expansion.ts
@@ -31,8 +31,7 @@ async function importSequenceTemplate(req: Request, res: Response) {
     headers: { 'x-hasura-role': roleHeader, 'x-hasura-user-id': userHeader },
   } = req;
 
-  const { body, file } = req;
-  const { activity_type, language, model_id, name, parcel_id } = body as ImportSequenceTemplatePayload;
+  const { activity_type, language, model_id, name, parcel_id, sequence_template_file } = req.body as ImportSequenceTemplatePayload;
 
   logger.info(`POST /importSequenceTemplate: Importing sequence template: ${name}`);
 
@@ -46,10 +45,6 @@ async function importSequenceTemplate(req: Request, res: Response) {
   let createdSequenceTemplate: SequenceTemplateSchema | null = null;
 
   try {
-    if (file === undefined) {
-      throw Error('No sequence template file was given in the request!');
-    }
-    const sequenceTemplateContent: string = file.buffer.toString();
     logger.info(`POST /importSequenceTemplate: Creating sequence template: ${name}`);
 
     const sequenceTemplateInsertInput: SequenceTemplateInsertInput = {
@@ -58,7 +53,7 @@ async function importSequenceTemplate(req: Request, res: Response) {
       model_id,
       name,
       parcel_id,
-      template_definition: sequenceTemplateContent,
+      template_definition: sequence_template_file,
     };
 
     // TODO: Add multi-import
@@ -100,7 +95,7 @@ export default (app: Express) => {
    *     security:
    *       - bearerAuth: []
    *     consumes:
-   *       - multipart/form-data
+   *       - application/json
    *     produces:
    *       - application/json
    *     parameters:
@@ -111,12 +106,11 @@ export default (app: Express) => {
    *          required: false
    *     requestBody:
    *       content:
-   *         multipart/form-data:
+   *         application/json:
    *          schema:
    *            type: object
    *            properties:
    *              sequence_template_file:
-   *                format: binary
    *                type: string
    *              activity_type:
    *                type: string
@@ -141,7 +135,6 @@ export default (app: Express) => {
    */
   app.post(
     '/importSequenceTemplate',
-    upload.single('sequence_template_file'),
     refreshLimiter,
     auth,
     importSequenceTemplate,

--- a/src/packages/expansion/gql.ts
+++ b/src/packages/expansion/gql.ts
@@ -1,0 +1,11 @@
+export default {
+  CREATE_SEQUENCE_TEMPLATE: `#graphql
+    mutation CreateSequenceTemplate($sequenceTemplateInsertInput: [sequence_template_insert_input!]!) {
+      insert_sequence_template(objects: $sequenceTemplateInsertInput) {
+        returning {
+          id
+        }
+      }
+    }
+  `,
+};

--- a/src/types/expansion.ts
+++ b/src/types/expansion.ts
@@ -4,6 +4,7 @@ export type ImportSequenceTemplatePayload = {
   model_id: number;
   name: string;
   parcel_id: number;
+  sequence_template_file: string;
 };
 
 export type SequenceTemplateInsertInput = {

--- a/src/types/expansion.ts
+++ b/src/types/expansion.ts
@@ -1,0 +1,18 @@
+export type ImportSequenceTemplatePayload = {
+  activity_type: string;
+  language: string;
+  model_id: number;
+  name: string;
+  parcel_id: number;
+};
+
+export type SequenceTemplateInsertInput = {
+  activity_type: string;
+  language: string;
+  model_id: number;
+  name: string;
+  parcel_id: number;
+  template_definition: string;
+};
+
+export type SequenceTemplateSchema = SequenceTemplateInsertInput & { id: number; owner: string };


### PR DESCRIPTION
This PR allows the upload of sequence templates via. Gateway - see https://github.com/NASA-AMMOS/aerie-ui/pull/1678 for the UI pull-request that utilizes this end-point.

Note, the gateway route does **not** parse the content of the template and instead just acts as a bridge to Hasura.