### PR TITLE
Support OIDC in PlanDev-UI by adding JWKS Support

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -3,4 +3,9 @@ GATEWAY_DB_PASSWORD=
 
 HASURA_API_URL=http://localhost:8080
 
+# JWT signing algorithms (JSON array). Default: ["RS256"]
+# JWT_ALGORITHMS=["RS256"]
+
+# JWT configuration. For OIDC/JWKS, include jwk_url, issuer, and audience:
+# HASURA_GRAPHQL_JWT_SECRET='{ "jwk_url": "https://your-oidc-provider/.well-known/jwks", "issuer": "https://your-oidc-provider", "audience": "your-client-id" }'
 HASURA_GRAPHQL_JWT_SECRET=

--- a/.env.template
+++ b/.env.template
@@ -9,3 +9,11 @@ HASURA_API_URL=http://localhost:8080
 # JWT configuration. For OIDC/JWKS, include jwk_url, issuer, and audience:
 # HASURA_GRAPHQL_JWT_SECRET='{ "jwk_url": "https://your-oidc-provider/.well-known/jwks", "issuer": "https://your-oidc-provider", "audience": "your-client-id" }'
 HASURA_GRAPHQL_JWT_SECRET=
+
+# JWT claim paths - customize where user ID, roles, etc. are read from in the JWT.
+# Defaults follow Hasura's JWT claims namespace convention.
+# These should match your OIDC provider's token mapper configuration.
+# JWT_CLAIMS_NAMESPACE=https://hasura.io/jwt/claims
+# JWT_CLAIMS_USER_ID=x-hasura-user-id
+# JWT_CLAIMS_ALLOWED_ROLES=x-hasura-allowed-roles
+# JWT_CLAIMS_DEFAULT_ROLE=x-hasura-default-role

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "express-rate-limit": "^6.7.0",
         "helmet": "^7.0.0",
         "jsonwebtoken": "^9.0.1",
+        "jwks-rsa": "^3.2.0",
         "multer": "^1.4.5-lts.1",
         "nanoid": "^4.0.2",
         "node-fetch": "^3.3.2",
@@ -883,7 +884,6 @@
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
       "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
-      "dev": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -893,7 +893,6 @@
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
       "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -923,10 +922,9 @@
       "dev": true
     },
     "node_modules/@types/express": {
-      "version": "4.17.17",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.17.tgz",
-      "integrity": "sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==",
-      "dev": true,
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.23.tgz",
+      "integrity": "sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==",
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -938,7 +936,6 @@
       "version": "4.17.35",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.35.tgz",
       "integrity": "sha512-wALWQwrgiB2AWTT91CB62b6Yt0sNHpznUXeZEcnPU3DRdlDIz74x8Qg1UUYKSVFi+va5vKOLYRBI1bRKiLLKIg==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -949,8 +946,7 @@
     "node_modules/@types/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ==",
-      "dev": true
+      "integrity": "sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ=="
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.12",
@@ -958,19 +954,23 @@
       "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA=="
     },
     "node_modules/@types/jsonwebtoken": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
-      "integrity": "sha512-drE6uz7QBKq1fYqqoFKTDRdFCPHd5TCub75BM+D+cMx7NU9hUz7SESLfC2fSCXVFMO5Yj8sOWHuGqPgjc+fz0Q==",
-      "dev": true,
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
       "dependencies": {
+        "@types/ms": "*",
         "@types/node": "*"
       }
     },
     "node_modules/@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
-      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
-      "dev": true
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
     },
     "node_modules/@types/multer": {
       "version": "1.4.7",
@@ -984,8 +984,7 @@
     "node_modules/@types/node": {
       "version": "20.4.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.0.tgz",
-      "integrity": "sha512-jfT7iTf/4kOQ9S7CHV9BIyRaQqHu67mOjsIQBC3BKZvzvUB6zLxEwJ6sBE3ozcvP8kF6Uk5PXN0Q+c0dfhGX0g==",
-      "dev": true
+      "integrity": "sha512-jfT7iTf/4kOQ9S7CHV9BIyRaQqHu67mOjsIQBC3BKZvzvUB6zLxEwJ6sBE3ozcvP8kF6Uk5PXN0Q+c0dfhGX0g=="
     },
     "node_modules/@types/pg": {
       "version": "8.10.2",
@@ -1001,14 +1000,12 @@
     "node_modules/@types/qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
-      "dev": true
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
-      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
-      "dev": true
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
     "node_modules/@types/semver": {
       "version": "7.5.0",
@@ -1020,7 +1017,6 @@
       "version": "0.17.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.1.tgz",
       "integrity": "sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==",
-      "dev": true,
       "dependencies": {
         "@types/mime": "^1",
         "@types/node": "*"
@@ -1030,7 +1026,6 @@
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.2.tgz",
       "integrity": "sha512-J2LqtvFYCzaj8pVYKw8klQXrLLk7TBZmQ4ShlcdkELFKGwGMfevMLneMMRkMgZxotOD9wg497LpC7O8PcvAmfw==",
-      "dev": true,
       "dependencies": {
         "@types/http-errors": "*",
         "@types/mime": "*",
@@ -1918,7 +1913,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -3024,6 +3018,14 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.0.tgz",
@@ -3083,6 +3085,22 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/jwks-rsa": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-3.2.0.tgz",
+      "integrity": "sha512-PwchfHcQK/5PSydeKCs1ylNym0w/SSv8a62DgHJ//7x2ZclCoinlsjAfDxAAbpoTPybOum/Jgy+vkvMmKz89Ww==",
+      "dependencies": {
+        "@types/express": "^4.17.20",
+        "@types/jsonwebtoken": "^9.0.4",
+        "debug": "^4.3.4",
+        "jose": "^4.15.4",
+        "limiter": "^1.1.5",
+        "lru-memoizer": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/jws": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
@@ -3109,6 +3127,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/limiter": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
     },
     "node_modules/local-pkg": {
       "version": "0.5.0",
@@ -3145,6 +3168,11 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
     },
     "node_modules/lodash.get": {
       "version": "4.4.2",
@@ -3198,6 +3226,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/lru-memoizer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.3.0.tgz",
+      "integrity": "sha512-GXn7gyHAMhO13WSKrIiNfztwxodVsP8IoZ3XfrJV4yH2x0/OeTO/FIaAHTY5YekdGgW94njfuKmyyt1E0mR6Ug==",
+      "dependencies": {
+        "lodash.clonedeep": "^4.5.0",
+        "lru-cache": "6.0.0"
       }
     },
     "node_modules/magic-string": {
@@ -5636,7 +5673,6 @@
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
       "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
-      "dev": true,
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -5646,7 +5682,6 @@
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
       "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -5676,10 +5711,9 @@
       "dev": true
     },
     "@types/express": {
-      "version": "4.17.17",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.17.tgz",
-      "integrity": "sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==",
-      "dev": true,
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.23.tgz",
+      "integrity": "sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==",
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -5691,7 +5725,6 @@
       "version": "4.17.35",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.35.tgz",
       "integrity": "sha512-wALWQwrgiB2AWTT91CB62b6Yt0sNHpznUXeZEcnPU3DRdlDIz74x8Qg1UUYKSVFi+va5vKOLYRBI1bRKiLLKIg==",
-      "dev": true,
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -5702,8 +5735,7 @@
     "@types/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ==",
-      "dev": true
+      "integrity": "sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ=="
     },
     "@types/json-schema": {
       "version": "7.0.12",
@@ -5711,19 +5743,23 @@
       "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA=="
     },
     "@types/jsonwebtoken": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
-      "integrity": "sha512-drE6uz7QBKq1fYqqoFKTDRdFCPHd5TCub75BM+D+cMx7NU9hUz7SESLfC2fSCXVFMO5Yj8sOWHuGqPgjc+fz0Q==",
-      "dev": true,
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
       "requires": {
+        "@types/ms": "*",
         "@types/node": "*"
       }
     },
     "@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
-      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
-      "dev": true
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
+    },
+    "@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
     },
     "@types/multer": {
       "version": "1.4.7",
@@ -5737,8 +5773,7 @@
     "@types/node": {
       "version": "20.4.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.0.tgz",
-      "integrity": "sha512-jfT7iTf/4kOQ9S7CHV9BIyRaQqHu67mOjsIQBC3BKZvzvUB6zLxEwJ6sBE3ozcvP8kF6Uk5PXN0Q+c0dfhGX0g==",
-      "dev": true
+      "integrity": "sha512-jfT7iTf/4kOQ9S7CHV9BIyRaQqHu67mOjsIQBC3BKZvzvUB6zLxEwJ6sBE3ozcvP8kF6Uk5PXN0Q+c0dfhGX0g=="
     },
     "@types/pg": {
       "version": "8.10.2",
@@ -5754,14 +5789,12 @@
     "@types/qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
-      "dev": true
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
     },
     "@types/range-parser": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
-      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
-      "dev": true
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
     "@types/semver": {
       "version": "7.5.0",
@@ -5773,7 +5806,6 @@
       "version": "0.17.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.1.tgz",
       "integrity": "sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==",
-      "dev": true,
       "requires": {
         "@types/mime": "^1",
         "@types/node": "*"
@@ -5783,7 +5815,6 @@
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.2.tgz",
       "integrity": "sha512-J2LqtvFYCzaj8pVYKw8klQXrLLk7TBZmQ4ShlcdkELFKGwGMfevMLneMMRkMgZxotOD9wg497LpC7O8PcvAmfw==",
-      "dev": true,
       "requires": {
         "@types/http-errors": "*",
         "@types/mime": "*",
@@ -6428,7 +6459,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -7244,6 +7274,11 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA=="
+    },
     "js-tokens": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.0.tgz",
@@ -7296,6 +7331,19 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "jwks-rsa": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-3.2.0.tgz",
+      "integrity": "sha512-PwchfHcQK/5PSydeKCs1ylNym0w/SSv8a62DgHJ//7x2ZclCoinlsjAfDxAAbpoTPybOum/Jgy+vkvMmKz89Ww==",
+      "requires": {
+        "@types/express": "^4.17.20",
+        "@types/jsonwebtoken": "^9.0.4",
+        "debug": "^4.3.4",
+        "jose": "^4.15.4",
+        "limiter": "^1.1.5",
+        "lru-memoizer": "^2.2.0"
+      }
+    },
     "jws": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
@@ -7320,6 +7368,11 @@
         "type-check": "~0.4.0"
       }
     },
+    "limiter": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
+    },
     "local-pkg": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.0.tgz",
@@ -7343,6 +7396,11 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -7393,6 +7451,15 @@
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "requires": {
         "yallist": "^4.0.0"
+      }
+    },
+    "lru-memoizer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.3.0.tgz",
+      "integrity": "sha512-GXn7gyHAMhO13WSKrIiNfztwxodVsP8IoZ3XfrJV4yH2x0/OeTO/FIaAHTY5YekdGgW94njfuKmyyt1E0mR6Ug==",
+      "requires": {
+        "lodash.clonedeep": "^4.5.0",
+        "lru-cache": "6.0.0"
       }
     },
     "magic-string": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "express": "^4.18.2",
     "express-rate-limit": "^6.7.0",
     "helmet": "^7.0.0",
+    "jwks-rsa": "^3.2.0",
     "jsonwebtoken": "^9.0.1",
     "multer": "^1.4.5-lts.1",
     "nanoid": "^4.0.2",

--- a/src/env.ts
+++ b/src/env.ts
@@ -48,7 +48,7 @@ export const defaultEnv: Env = {
   GQL_API_WS_URL: 'ws://localhost:8080/v1/graphql',
   HASURA_API_URL: 'http://hasura:8080',
   HASURA_GRAPHQL_JWT_SECRET: '',
-  JWT_ALGORITHMS: ['HS256'],
+  JWT_ALGORITHMS: ['RS256'],
   JWT_EXPIRATION: '36h' as StringValue,
   LOG_FILE: 'console',
   LOG_LEVEL: 'info',

--- a/src/env.ts
+++ b/src/env.ts
@@ -2,6 +2,18 @@ import type { Algorithm } from 'jsonwebtoken';
 import { GroupRoleMapping } from './types/auth';
 import { StringValue } from 'ms';
 
+/**
+ * JWT claim path configuration.
+ * Allows customization of where user ID, roles, and other claims are read from in the JWT.
+ * Defaults follow Hasura's JWT claims namespace convention.
+ */
+export type JwtClaimsConfig = {
+  namespace: string;
+  userId: string;
+  allowedRoles: string;
+  defaultRole: string;
+};
+
 export type Env = {
   ALLOWED_ROLES: string[];
   ALLOWED_ROLES_NO_AUTH: string[];
@@ -17,6 +29,7 @@ export type Env = {
   HASURA_API_URL: string;
   HASURA_GRAPHQL_JWT_SECRET: string;
   JWT_ALGORITHMS: Algorithm[];
+  JWT_CLAIMS: JwtClaimsConfig;
   JWT_EXPIRATION: StringValue;
   LOG_FILE: string;
   LOG_LEVEL: string;
@@ -28,6 +41,13 @@ export type Env = {
   RATE_LIMITER_FILES_MAX: number;
   RATE_LIMITER_LOGIN_MAX: number;
   VERSION: string;
+};
+
+export const defaultJwtClaims: JwtClaimsConfig = {
+  namespace: 'https://hasura.io/jwt/claims',
+  userId: 'x-hasura-user-id',
+  allowedRoles: 'x-hasura-allowed-roles',
+  defaultRole: 'x-hasura-default-role',
 };
 
 export const defaultEnv: Env = {
@@ -49,6 +69,7 @@ export const defaultEnv: Env = {
   HASURA_API_URL: 'http://hasura:8080',
   HASURA_GRAPHQL_JWT_SECRET: '',
   JWT_ALGORITHMS: ['RS256'],
+  JWT_CLAIMS: defaultJwtClaims,
   JWT_EXPIRATION: '36h' as StringValue,
   LOG_FILE: 'console',
   LOG_LEVEL: 'info',
@@ -121,6 +142,12 @@ export function getEnv(): Env {
   const HASURA_GRAPHQL_JWT_SECRET = env['HASURA_GRAPHQL_JWT_SECRET'] ?? defaultEnv.HASURA_GRAPHQL_JWT_SECRET;
   const HASURA_API_URL = env['HASURA_API_URL'] ?? defaultEnv.HASURA_API_URL;
   const JWT_ALGORITHMS = parseArray(env['JWT_ALGORITHMS'], defaultEnv.JWT_ALGORITHMS);
+  const JWT_CLAIMS: JwtClaimsConfig = {
+    namespace: env['JWT_CLAIMS_NAMESPACE'] ?? defaultJwtClaims.namespace,
+    userId: env['JWT_CLAIMS_USER_ID'] ?? defaultJwtClaims.userId,
+    allowedRoles: env['JWT_CLAIMS_ALLOWED_ROLES'] ?? defaultJwtClaims.allowedRoles,
+    defaultRole: env['JWT_CLAIMS_DEFAULT_ROLE'] ?? defaultJwtClaims.defaultRole,
+  };
   const JWT_EXPIRATION = (env['JWT_EXPIRATION'] as StringValue) ?? defaultEnv.JWT_EXPIRATION;
   const LOG_FILE = env['LOG_FILE'] ?? defaultEnv.LOG_FILE;
   const LOG_LEVEL = env['LOG_LEVEL'] ?? defaultEnv.LOG_LEVEL;
@@ -152,6 +179,7 @@ export function getEnv(): Env {
     HASURA_API_URL,
     HASURA_GRAPHQL_JWT_SECRET,
     JWT_ALGORITHMS,
+    JWT_CLAIMS,
     JWT_EXPIRATION,
     LOG_FILE,
     LOG_LEVEL,

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,5 +1,6 @@
 import type { Algorithm } from 'jsonwebtoken';
 import { GroupRoleMapping } from './types/auth';
+import { StringValue } from 'ms';
 
 export type Env = {
   ALLOWED_ROLES: string[];
@@ -16,7 +17,7 @@ export type Env = {
   HASURA_API_URL: string;
   HASURA_GRAPHQL_JWT_SECRET: string;
   JWT_ALGORITHMS: Algorithm[];
-  JWT_EXPIRATION: string;
+  JWT_EXPIRATION: StringValue;
   LOG_FILE: string;
   LOG_LEVEL: string;
   PORT: string;
@@ -48,7 +49,7 @@ export const defaultEnv: Env = {
   HASURA_API_URL: 'http://hasura:8080',
   HASURA_GRAPHQL_JWT_SECRET: '',
   JWT_ALGORITHMS: ['HS256'],
-  JWT_EXPIRATION: '36h',
+  JWT_EXPIRATION: '36h' as StringValue,
   LOG_FILE: 'console',
   LOG_LEVEL: 'info',
   PORT: '9000',
@@ -120,7 +121,7 @@ export function getEnv(): Env {
   const HASURA_GRAPHQL_JWT_SECRET = env['HASURA_GRAPHQL_JWT_SECRET'] ?? defaultEnv.HASURA_GRAPHQL_JWT_SECRET;
   const HASURA_API_URL = env['HASURA_API_URL'] ?? defaultEnv.HASURA_API_URL;
   const JWT_ALGORITHMS = parseArray(env['JWT_ALGORITHMS'], defaultEnv.JWT_ALGORITHMS);
-  const JWT_EXPIRATION = env['JWT_EXPIRATION'] ?? defaultEnv.JWT_EXPIRATION;
+  const JWT_EXPIRATION = (env['JWT_EXPIRATION'] as StringValue) ?? defaultEnv.JWT_EXPIRATION;
   const LOG_FILE = env['LOG_FILE'] ?? defaultEnv.LOG_FILE;
   const LOG_LEVEL = env['LOG_LEVEL'] ?? defaultEnv.LOG_LEVEL;
   const PORT = env['PORT'] ?? defaultEnv.PORT;

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,4 +1,3 @@
-import type { Algorithm } from 'jsonwebtoken';
 import { GroupRoleMapping } from './types/auth';
 import { StringValue } from 'ms';
 
@@ -28,7 +27,6 @@ export type Env = {
   GQL_API_WS_URL: string;
   HASURA_API_URL: string;
   HASURA_GRAPHQL_JWT_SECRET: string;
-  JWT_ALGORITHMS: Algorithm[];
   JWT_CLAIMS: JwtClaimsConfig;
   JWT_EXPIRATION: StringValue;
   LOG_FILE: string;
@@ -68,7 +66,6 @@ export const defaultEnv: Env = {
   GQL_API_WS_URL: 'ws://localhost:8080/v1/graphql',
   HASURA_API_URL: 'http://hasura:8080',
   HASURA_GRAPHQL_JWT_SECRET: '',
-  JWT_ALGORITHMS: ['RS256'],
   JWT_CLAIMS: defaultJwtClaims,
   JWT_EXPIRATION: '36h' as StringValue,
   LOG_FILE: 'console',
@@ -141,7 +138,6 @@ export function getEnv(): Env {
   const GQL_API_WS_URL = env['GQL_API_WS_URL'] ?? defaultEnv.GQL_API_WS_URL;
   const HASURA_GRAPHQL_JWT_SECRET = env['HASURA_GRAPHQL_JWT_SECRET'] ?? defaultEnv.HASURA_GRAPHQL_JWT_SECRET;
   const HASURA_API_URL = env['HASURA_API_URL'] ?? defaultEnv.HASURA_API_URL;
-  const JWT_ALGORITHMS = parseArray(env['JWT_ALGORITHMS'], defaultEnv.JWT_ALGORITHMS);
   const JWT_CLAIMS: JwtClaimsConfig = {
     namespace: env['JWT_CLAIMS_NAMESPACE'] ?? defaultJwtClaims.namespace,
     userId: env['JWT_CLAIMS_USER_ID'] ?? defaultJwtClaims.userId,
@@ -178,7 +174,6 @@ export function getEnv(): Env {
     GQL_API_WS_URL,
     HASURA_API_URL,
     HASURA_GRAPHQL_JWT_SECRET,
-    JWT_ALGORITHMS,
     JWT_CLAIMS,
     JWT_EXPIRATION,
     LOG_FILE,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,23 +1,23 @@
+import cookieParser from 'cookie-parser';
 import cors from 'cors';
 import express from 'express';
 import helmet from 'helmet';
 import { getEnv } from './env.js';
 import getLogger from './logger.js';
 import initApiPlaygroundRoutes from './packages/api-playground/api-playground.js';
+import { CAMAuthAdapter } from './packages/auth/adapters/CAMAuthAdapter.js';
+import { NoAuthAdapter } from './packages/auth/adapters/NoAuthAdapter.js';
+import { validateGroupRoleMappings } from './packages/auth/functions.js';
 import initAuthRoutes from './packages/auth/routes.js';
-import initExpansionRoutes from './packages/expansion/expansion.js';
 import { DbMerlin } from './packages/db/db.js';
+import initExpansionRoutes from './packages/expansion/expansion.js';
+import initExternalSourceRoutes from './packages/external-source/external-source.js';
 import initFileRoutes from './packages/files/files.js';
 import initHasuraRoutes from './packages/hasura/hasura-events.js';
 import initHealthRoutes from './packages/health/health.js';
 import initPlanRoutes from './packages/plan/plan.js';
 import initSwaggerRoutes from './packages/swagger/swagger.js';
-import initExternalSourceRoutes from './packages/external-source/external-source.js';
-import cookieParser from 'cookie-parser';
 import { AuthAdapter } from './types/auth.js';
-import { NoAuthAdapter } from './packages/auth/adapters/NoAuthAdapter.js';
-import { CAMAuthAdapter } from './packages/auth/adapters/CAMAuthAdapter.js';
-import { validateGroupRoleMappings } from './packages/auth/functions.js';
 
 async function main(): Promise<void> {
   const logger = getLogger('main');

--- a/src/packages/auth/functions.ts
+++ b/src/packages/auth/functions.ts
@@ -121,12 +121,19 @@ function enforcePEMFormatting(publicKey: string): string {
 export async function decodeJwt(authorizationHeader: string | undefined): Promise<JwtDecode> {
   try {
     const token = authorizationHeaderToToken(authorizationHeader);
-    // TODO: this ignores the JWT_ALGORITHMS env variable, because that's included in HASURA_GRAPHQL_JWT_SECRET, both the keycloak version, and even the local version...
-    const { HASURA_GRAPHQL_JWT_SECRET } = getEnv();
-    const { type, key, jwk_url }: JwtSecret = JSON.parse(HASURA_GRAPHQL_JWT_SECRET);
+    const { HASURA_GRAPHQL_JWT_SECRET, JWT_ALGORITHMS } = getEnv();
+    const { type, key, jwk_url, issuer, audience }: JwtSecret = JSON.parse(HASURA_GRAPHQL_JWT_SECRET);
 
-    // TODO: figure out the defaults, for some reason the JWT_ALGORITHM env variable and it's default were getting messed up...default _should_ be HS256, but if using Keycloak, need RS256
-    const options: jwt.VerifyOptions = { algorithms: ['RS256', 'HS256'] };
+    const options: jwt.VerifyOptions = { algorithms: JWT_ALGORITHMS };
+
+    // Add issuer/audience validation if configured (used with JWKS/OIDC)
+    if (issuer) {
+      options.issuer = issuer;
+    }
+    if (audience) {
+      // jwt.verify expects string or non-empty array
+      options.audience = Array.isArray(audience) ? audience as [string, ...string[]] : audience;
+    }
 
     type getKeyType = (header: JwtHeader, callback: any) => void;
     let realKey: string | getKeyType;
@@ -140,12 +147,13 @@ export async function decodeJwt(authorizationHeader: string | undefined): Promis
 
       realKey = function(header, callback) {
         client.getSigningKey(header.kid, function(err, key) {
-          if (key) {
-            const signingKey = key?.getPublicKey();
+          if (err) {
+            callback(err, null);
+          } else if (key) {
+            const signingKey = key.getPublicKey();
             callback(null, signingKey);
-          }
-          else {
-            console.log(err)
+          } else {
+            callback(new Error('No signing key found'), null);
           }
         });
       }

--- a/src/packages/auth/functions.ts
+++ b/src/packages/auth/functions.ts
@@ -211,15 +211,15 @@ export function generateJwt(
   expiry: StringValue = getEnv().JWT_EXPIRATION,
 ): string | null {
   try {
-    const { HASURA_GRAPHQL_JWT_SECRET } = getEnv();
+    const { HASURA_GRAPHQL_JWT_SECRET, JWT_CLAIMS } = getEnv();
     const { key, type }: JwtSecret = JSON.parse(HASURA_GRAPHQL_JWT_SECRET);
     if (key) {
       const options: jwt.SignOptions = { algorithm: type as Algorithm, expiresIn: expiry };
       const payload: JwtPayload = {
-        'https://hasura.io/jwt/claims': {
-          'x-hasura-allowed-roles': allowedRoles,
-          'x-hasura-default-role': defaultRole,
-          'x-hasura-user-id': username,
+        [JWT_CLAIMS.namespace]: {
+          [JWT_CLAIMS.allowedRoles]: allowedRoles,
+          [JWT_CLAIMS.defaultRole]: defaultRole,
+          [JWT_CLAIMS.userId]: username,
         },
         username,
       };

--- a/src/packages/auth/functions.ts
+++ b/src/packages/auth/functions.ts
@@ -1,4 +1,4 @@
-import jwt, { Algorithm } from 'jsonwebtoken';
+import jwt, { Algorithm, JwtHeader, VerifyOptions } from 'jsonwebtoken';
 import type { Response } from 'node-fetch';
 import fetch from 'node-fetch';
 import { getEnv } from '../../env.js';
@@ -14,6 +14,8 @@ import type {
   UserRoles,
 } from '../../types/auth.js';
 import { loginSSO } from './adapters/CAMAuthAdapter.js';
+import { JwksClient } from 'jwks-rsa';
+import { StringValue } from 'ms';
 
 const logger = getLogger('packages/auth/functions');
 
@@ -107,14 +109,78 @@ export async function syncRolesToDB(username: string, default_role: string, allo
   await db.query('commit;');
 }
 
-export function decodeJwt(authorizationHeader: string | undefined): JwtDecode {
+function enforcePEMFormatting(publicKey: string): string {
+  if (publicKey.includes('-----BEGIN PUBLIC KEY-----') && publicKey.includes('-----END PUBLIC KEY-----')) {
+    return publicKey;
+  }
+  else {
+    return '-----BEGIN PUBLIC KEY-----\n' + publicKey + '\n-----END PUBLIC KEY-----'
+  }
+}
+
+export async function decodeJwt(authorizationHeader: string | undefined): Promise<JwtDecode> {
   try {
     const token = authorizationHeaderToToken(authorizationHeader);
-    const { HASURA_GRAPHQL_JWT_SECRET, JWT_ALGORITHMS } = getEnv();
-    const { key }: JwtSecret = JSON.parse(HASURA_GRAPHQL_JWT_SECRET);
-    const options: jwt.VerifyOptions = { algorithms: JWT_ALGORITHMS };
-    const jwtPayload = jwt.verify(token, key, options) as JwtPayload;
-    return { jwtErrorMessage: '', jwtPayload };
+    // TODO: this ignores the JWT_ALGORITHMS env variable, because that's included in HASURA_GRAPHQL_JWT_SECRET, both the keycloak version, and even the local version...
+    const { HASURA_GRAPHQL_JWT_SECRET } = getEnv();
+    const { type, key, jwk_url }: JwtSecret = JSON.parse(HASURA_GRAPHQL_JWT_SECRET);
+
+    // TODO: figure out the defaults, for some reason the JWT_ALGORITHM env variable and it's default were getting messed up...default _should_ be HS256, but if using Keycloak, need RS256
+    const options: jwt.VerifyOptions = { algorithms: ['RS256', 'HS256'] };
+
+    type getKeyType = (header: JwtHeader, callback: any) => void;
+    let realKey: string | getKeyType;
+
+    // if they are using a jwk_url instead, pull the key!
+    if (!key && jwk_url) {
+      // https://www.npmjs.com/package/jsonwebtoken
+      const client = new JwksClient({
+        jwksUri: jwk_url
+      });
+
+      realKey = function(header, callback) {
+        client.getSigningKey(header.kid, function(err, key) {
+          if (key) {
+            const signingKey = key?.getPublicKey();
+            callback(null, signingKey);
+          }
+          else {
+            console.log(err)
+          }
+        });
+      }
+
+      const verifyJwt = async function(token: string, options: VerifyOptions = {}): Promise<any> {
+        return new Promise((resolve, reject) => {
+          jwt.verify(token, realKey, options, (err, decoded) => {
+            if (err) return reject(err);
+            resolve(decoded);
+          });
+        });
+      }
+
+      try {
+        const jwtPayload = await verifyJwt(token, options);
+        return {jwtErrorMessage: '', jwtPayload: jwtPayload}
+      } catch (err) {
+        return {jwtErrorMessage: 'JWT verification failed: ' + err, jwtPayload: null}
+      }
+    }
+    else if (key) {
+      if (type === "RS256") {
+        realKey = enforcePEMFormatting(key);
+      }
+      else {
+        realKey = key;
+      }
+
+      const jwtPayload = jwt.verify(token, realKey, options) as JwtPayload;
+      return { jwtErrorMessage: '', jwtPayload };
+    }
+    else {
+      const jwtErrorMessage = 'Neither a valid JWT Key or JWK URL were provided. A type (algorithm) and either of those two must be provided.'
+      return { jwtErrorMessage, jwtPayload: null };
+    }
   } catch (e) {
     console.error(e);
 
@@ -134,22 +200,26 @@ export function generateJwt(
   username: string,
   defaultRole: string,
   allowedRoles: string[],
-  expiry: string = getEnv().JWT_EXPIRATION,
+  expiry: StringValue = getEnv().JWT_EXPIRATION,
 ): string | null {
   try {
     const { HASURA_GRAPHQL_JWT_SECRET } = getEnv();
     const { key, type }: JwtSecret = JSON.parse(HASURA_GRAPHQL_JWT_SECRET);
-    const options: jwt.SignOptions = { algorithm: type as Algorithm, expiresIn: expiry };
-    const payload: JwtPayload = {
-      'https://hasura.io/jwt/claims': {
-        'x-hasura-allowed-roles': allowedRoles,
-        'x-hasura-default-role': defaultRole,
-        'x-hasura-user-id': username,
-      },
-      username,
-    };
+    if (key) {
+      const options: jwt.SignOptions = { algorithm: type as Algorithm, expiresIn: expiry };
+      const payload: JwtPayload = {
+        'https://hasura.io/jwt/claims': {
+          'x-hasura-allowed-roles': allowedRoles,
+          'x-hasura-default-role': defaultRole,
+          'x-hasura-user-id': username,
+        },
+        username,
+      };
 
-    return jwt.sign(payload, key, options);
+      return jwt.sign(payload, key, options);
+    }
+    console.error('using JWKS URL, so this JWT generation will not work. You also shouldn\'t be using this method if using JWKS')
+    return null;
   } catch (e) {
     console.error(e);
     return null;
@@ -210,7 +280,7 @@ export async function login(username: string, password: string): Promise<AuthRes
 }
 
 export async function session(authorizationHeader: string | undefined): Promise<SessionResponse> {
-  const { jwtErrorMessage, jwtPayload } = decodeJwt(authorizationHeader);
+  const { jwtErrorMessage, jwtPayload } = await decodeJwt(authorizationHeader);
 
   if (jwtPayload) {
     return { message: 'Token is valid', success: true };

--- a/src/packages/auth/functions.ts
+++ b/src/packages/auth/functions.ts
@@ -291,6 +291,29 @@ export async function session(authorizationHeader: string | undefined): Promise<
   const { jwtErrorMessage, jwtPayload } = await decodeJwt(authorizationHeader);
 
   if (jwtPayload) {
+    // Lazy-upsert the user's permissions row on first sight.
+    //
+    // For gateway-issued JWTs (JWT/SSO modes), login() already provisioned the row,
+    // so the SELECT inside getUserRoles is a no-op for existing users. For
+    // Keycloak-issued OIDC tokens this is the *only* place provisioning happens —
+    // the UI's user-scoped JWT lacks Hasura insert permission on permissions.users.
+    //
+    // Failure here must not block session validation (token is still valid even if
+    // the DB write hiccups); log and continue.
+    try {
+      const { JWT_CLAIMS } = getEnv();
+      const namespace = (jwtPayload as Record<string, unknown>)[JWT_CLAIMS.namespace] as
+        | Record<string, unknown>
+        | undefined;
+      const username = namespace?.[JWT_CLAIMS.userId];
+      const default_role = namespace?.[JWT_CLAIMS.defaultRole];
+      const allowed_roles = namespace?.[JWT_CLAIMS.allowedRoles];
+      if (typeof username === 'string' && typeof default_role === 'string' && Array.isArray(allowed_roles)) {
+        await getUserRoles(username, default_role, allowed_roles as string[]);
+      }
+    } catch (err) {
+      console.error('User provisioning during session validation failed:', err);
+    }
     return { message: 'Token is valid', success: true };
   } else {
     return { message: jwtErrorMessage, success: false };

--- a/src/packages/auth/functions.ts
+++ b/src/packages/auth/functions.ts
@@ -121,10 +121,16 @@ function enforcePEMFormatting(publicKey: string): string {
 export async function decodeJwt(authorizationHeader: string | undefined): Promise<JwtDecode> {
   try {
     const token = authorizationHeaderToToken(authorizationHeader);
-    const { HASURA_GRAPHQL_JWT_SECRET, JWT_ALGORITHMS } = getEnv();
+    const { HASURA_GRAPHQL_JWT_SECRET } = getEnv();
     const { type, key, jwk_url, issuer, audience }: JwtSecret = JSON.parse(HASURA_GRAPHQL_JWT_SECRET);
 
-    const options: jwt.VerifyOptions = { algorithms: JWT_ALGORITHMS };
+    // Bind the accepted algorithm to the secret's declared `type` (the same value generateJwt signs
+    // with), rather than a global JWT_ALGORITHMS default. This keeps HS256 and RS256/JWKS
+    // deployments self-configuring from their own secret — no reliance on a process-wide default
+    // that can only be correct for one mode — and, critically, prevents an RS256->HS256
+    // algorithm-confusion forgery: a JWKS/RS256 verifier never accepts an HS256 token signed with
+    // the (public) RSA key. `alg: none` is excluded for the same reason.
+    const options: jwt.VerifyOptions = { algorithms: [type as Algorithm] };
 
     // Add issuer/audience validation if configured (used with JWKS/OIDC)
     if (issuer) {

--- a/src/packages/auth/middleware.ts
+++ b/src/packages/auth/middleware.ts
@@ -18,7 +18,7 @@ export const adminOnlyAuth = async (req: Request, res: Response, next: NextFunct
   const response = await session(authorizationHeader);
 
   if (response.success) {
-    const { jwtPayload } = decodeJwt(authorizationHeader);
+    const { jwtPayload } = await decodeJwt(authorizationHeader);
     if (jwtPayload == null) {
       res.status(401).send({ message: 'No authorization headers present.' });
       return;

--- a/src/packages/auth/middleware.ts
+++ b/src/packages/auth/middleware.ts
@@ -1,4 +1,5 @@
 import type { NextFunction, Request, Response } from 'express';
+import { getEnv } from '../../env.js';
 import { decodeJwt, session } from './functions.js';
 
 export const auth = async (req: Request, res: Response, next: NextFunction) => {
@@ -24,8 +25,15 @@ export const adminOnlyAuth = async (req: Request, res: Response, next: NextFunct
       return;
     }
 
-    const defaultRole = jwtPayload['https://hasura.io/jwt/claims']['x-hasura-default-role'] as string;
-    const allowedRoles = jwtPayload['https://hasura.io/jwt/claims']['x-hasura-allowed-roles'] as string[];
+    const { JWT_CLAIMS } = getEnv();
+    const namespace = jwtPayload[JWT_CLAIMS.namespace] as Record<string, string | string[]>;
+    if (!namespace) {
+      res.status(401).send({ message: `JWT missing claims namespace: ${JWT_CLAIMS.namespace}` });
+      return;
+    }
+
+    const defaultRole = namespace[JWT_CLAIMS.defaultRole] as string;
+    const allowedRoles = namespace[JWT_CLAIMS.allowedRoles] as string[];
 
     const { headers } = req;
     const { 'x-hasura-role': role } = headers;

--- a/src/packages/hasura/hasura-events.ts
+++ b/src/packages/hasura/hasura-events.ts
@@ -52,7 +52,7 @@ export default (app: Express) => {
    *       - Hasura
    */
   app.post('/modelExtraction', refreshLimiter, adminOnlyAuth, async (req, res) => {
-    const { jwtPayload } = decodeJwt(req.get('authorization'));
+    const { jwtPayload } = await decodeJwt(req.get('authorization'));
     const username = jwtPayload?.username as string;
 
     const { body } = req;

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -7,8 +7,10 @@ export type JwtDecode = {
   jwtPayload: JwtPayload | null;
 };
 
+// JWT payload with configurable claims namespace
+// The namespace key is dynamic (configured via JWT_CLAIMS_NAMESPACE)
 export type JwtPayload = {
-  'https://hasura.io/jwt/claims': Record<string, string | string[]>;
+  [namespace: string]: Record<string, string | string[]> | string;
   username: string;
 };
 

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -13,8 +13,11 @@ export type JwtPayload = {
 };
 
 export type JwtSecret = {
-  key: string;
   type: string;
+
+  // either key or jwk_url
+  key?: string; 
+  jwk_url?: string;
 };
 
 export type AuthResponse = {

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -16,8 +16,12 @@ export type JwtSecret = {
   type: string;
 
   // either key or jwk_url
-  key?: string; 
+  key?: string;
   jwk_url?: string;
+
+  // optional validation fields (used with JWKS/OIDC)
+  issuer?: string;
+  audience?: string | string[];
 };
 
 export type AuthResponse = {

--- a/test/jwt.test.ts
+++ b/test/jwt.test.ts
@@ -301,3 +301,91 @@ describe('decodeJwt with HS256 static key', () => {
     expect(result.jwtErrorMessage).toContain('invalid signature');
   });
 });
+
+describe('configurable JWT claim paths', () => {
+  beforeEach(() => {
+    vi.stubEnv('JWT_ALGORITHMS', JSON.stringify(['RS256']));
+    vi.stubEnv(
+      'HASURA_GRAPHQL_JWT_SECRET',
+      JSON.stringify({
+        type: 'RS256',
+        key: publicKey,
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test('reads claims from default Hasura namespace', async () => {
+    // Default namespace: https://hasura.io/jwt/claims
+    const payload = {
+      'https://hasura.io/jwt/claims': {
+        'x-hasura-allowed-roles': ['admin', 'user'],
+        'x-hasura-default-role': 'admin',
+        'x-hasura-user-id': 'user-123',
+      },
+      username: 'user-123',
+    };
+    const token = signToken(payload);
+
+    const result = await decodeJwt(`Bearer ${token}`);
+
+    expect(result.jwtErrorMessage).toBe('');
+    expect(result.jwtPayload).not.toBeNull();
+    const namespace = result.jwtPayload?.['https://hasura.io/jwt/claims'] as Record<string, unknown>;
+    expect(namespace['x-hasura-user-id']).toBe('user-123');
+    expect(namespace['x-hasura-allowed-roles']).toEqual(['admin', 'user']);
+    expect(namespace['x-hasura-default-role']).toBe('admin');
+  });
+
+  test('reads claims from custom namespace when configured', async () => {
+    // Custom namespace
+    vi.stubEnv('JWT_CLAIMS_NAMESPACE', 'custom/claims');
+    vi.stubEnv('JWT_CLAIMS_USER_ID', 'sub');
+    vi.stubEnv('JWT_CLAIMS_ALLOWED_ROLES', 'roles');
+    vi.stubEnv('JWT_CLAIMS_DEFAULT_ROLE', 'primary_role');
+
+    const payload = {
+      'custom/claims': {
+        sub: 'custom-user-456',
+        roles: ['editor', 'viewer'],
+        primary_role: 'editor',
+      },
+      username: 'custom-user-456',
+    };
+    const token = signToken(payload);
+
+    const result = await decodeJwt(`Bearer ${token}`);
+
+    expect(result.jwtErrorMessage).toBe('');
+    expect(result.jwtPayload).not.toBeNull();
+    const namespace = result.jwtPayload?.['custom/claims'] as Record<string, unknown>;
+    expect(namespace['sub']).toBe('custom-user-456');
+    expect(namespace['roles']).toEqual(['editor', 'viewer']);
+    expect(namespace['primary_role']).toBe('editor');
+  });
+
+  test('supports Keycloak-style claim paths', async () => {
+    // Keycloak typically uses realm_access.roles or resource_access
+    vi.stubEnv('JWT_CLAIMS_NAMESPACE', 'realm_access');
+    vi.stubEnv('JWT_CLAIMS_ALLOWED_ROLES', 'roles');
+
+    const payload = {
+      realm_access: {
+        roles: ['aerie_admin', 'aerie_user'],
+      },
+      preferred_username: 'keycloak-user',
+      username: 'keycloak-user',
+    };
+    const token = signToken(payload);
+
+    const result = await decodeJwt(`Bearer ${token}`);
+
+    expect(result.jwtErrorMessage).toBe('');
+    expect(result.jwtPayload).not.toBeNull();
+    const namespace = result.jwtPayload?.['realm_access'] as Record<string, unknown>;
+    expect(namespace['roles']).toEqual(['aerie_admin', 'aerie_user']);
+  });
+});

--- a/test/jwt.test.ts
+++ b/test/jwt.test.ts
@@ -1,0 +1,303 @@
+import { generateKeyPairSync } from 'crypto';
+import jwt from 'jsonwebtoken';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { authorizationHeaderToToken, decodeJwt } from '../src/packages/auth/functions';
+
+// Generate RSA key pair for testing
+const { publicKey, privateKey } = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+});
+
+// Helper to create a valid JWT payload with Hasura claims
+function createPayload(overrides = {}) {
+  return {
+    'https://hasura.io/jwt/claims': {
+      'x-hasura-allowed-roles': ['user', 'viewer'],
+      'x-hasura-default-role': 'user',
+      'x-hasura-user-id': 'test-user',
+    },
+    username: 'test-user',
+    iss: 'https://test-issuer.example.com',
+    aud: 'test-audience',
+    ...overrides,
+  };
+}
+
+// Helper to sign a JWT with RS256
+function signToken(payload: object, options: jwt.SignOptions = {}) {
+  return jwt.sign(payload, privateKey, { algorithm: 'RS256', expiresIn: '1h', ...options });
+}
+
+describe('authorizationHeaderToToken', () => {
+  test('extracts token from valid Bearer header', () => {
+    const token = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.test';
+    const result = authorizationHeaderToToken(`Bearer ${token}`);
+    expect(result).toBe(token);
+  });
+
+  test('throws error when Bearer prefix is missing', () => {
+    expect(() => authorizationHeaderToToken('token-without-bearer')).toThrow(
+      "Authorization header does not include 'Bearer' prefix",
+    );
+  });
+
+  test('throws error when header is undefined', () => {
+    expect(() => authorizationHeaderToToken(undefined)).toThrow('Authorization header not found');
+  });
+
+  test('throws error when header is null', () => {
+    expect(() => authorizationHeaderToToken(null)).toThrow('Authorization header not found');
+  });
+});
+
+describe('decodeJwt with RS256 static key', () => {
+  beforeEach(() => {
+    vi.stubEnv('JWT_ALGORITHMS', JSON.stringify(['RS256']));
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test('successfully verifies valid token with RS256 static key', async () => {
+    const jwtSecret = JSON.stringify({
+      type: 'RS256',
+      key: publicKey,
+    });
+    vi.stubEnv('HASURA_GRAPHQL_JWT_SECRET', jwtSecret);
+
+    const payload = createPayload();
+    const token = signToken(payload);
+
+    const result = await decodeJwt(`Bearer ${token}`);
+
+    expect(result.jwtErrorMessage).toBe('');
+    expect(result.jwtPayload).not.toBeNull();
+    expect(result.jwtPayload?.username).toBe('test-user');
+  });
+
+  test('rejects token with wrong issuer when issuer validation is configured', async () => {
+    const jwtSecret = JSON.stringify({
+      type: 'RS256',
+      key: publicKey,
+      issuer: 'https://expected-issuer.example.com',
+    });
+    vi.stubEnv('HASURA_GRAPHQL_JWT_SECRET', jwtSecret);
+
+    const payload = createPayload({ iss: 'https://wrong-issuer.example.com' });
+    const token = signToken(payload);
+
+    const result = await decodeJwt(`Bearer ${token}`);
+
+    expect(result.jwtPayload).toBeNull();
+    expect(result.jwtErrorMessage).toContain('jwt issuer invalid');
+  });
+
+  test('rejects token with wrong audience when audience validation is configured', async () => {
+    const jwtSecret = JSON.stringify({
+      type: 'RS256',
+      key: publicKey,
+      audience: 'expected-audience',
+    });
+    vi.stubEnv('HASURA_GRAPHQL_JWT_SECRET', jwtSecret);
+
+    const payload = createPayload({ aud: 'wrong-audience' });
+    const token = signToken(payload);
+
+    const result = await decodeJwt(`Bearer ${token}`);
+
+    expect(result.jwtPayload).toBeNull();
+    expect(result.jwtErrorMessage).toContain('jwt audience invalid');
+  });
+
+  test('accepts token when issuer matches configured issuer', async () => {
+    const expectedIssuer = 'https://keycloak.example.com/realms/test';
+    const jwtSecret = JSON.stringify({
+      type: 'RS256',
+      key: publicKey,
+      issuer: expectedIssuer,
+    });
+    vi.stubEnv('HASURA_GRAPHQL_JWT_SECRET', jwtSecret);
+
+    const payload = createPayload({ iss: expectedIssuer });
+    const token = signToken(payload);
+
+    const result = await decodeJwt(`Bearer ${token}`);
+
+    expect(result.jwtErrorMessage).toBe('');
+    expect(result.jwtPayload).not.toBeNull();
+  });
+
+  test('accepts token when audience matches configured audience', async () => {
+    const expectedAudience = 'aerie';
+    const jwtSecret = JSON.stringify({
+      type: 'RS256',
+      key: publicKey,
+      audience: expectedAudience,
+    });
+    vi.stubEnv('HASURA_GRAPHQL_JWT_SECRET', jwtSecret);
+
+    const payload = createPayload({ aud: expectedAudience });
+    const token = signToken(payload);
+
+    const result = await decodeJwt(`Bearer ${token}`);
+
+    expect(result.jwtErrorMessage).toBe('');
+    expect(result.jwtPayload).not.toBeNull();
+  });
+
+  test('accepts token when audience is in array of allowed audiences', async () => {
+    const jwtSecret = JSON.stringify({
+      type: 'RS256',
+      key: publicKey,
+      audience: ['aerie', 'other-service'],
+    });
+    vi.stubEnv('HASURA_GRAPHQL_JWT_SECRET', jwtSecret);
+
+    const payload = createPayload({ aud: 'aerie' });
+    const token = signToken(payload);
+
+    const result = await decodeJwt(`Bearer ${token}`);
+
+    expect(result.jwtErrorMessage).toBe('');
+    expect(result.jwtPayload).not.toBeNull();
+  });
+
+  test('validates both issuer and audience when both are configured', async () => {
+    const jwtSecret = JSON.stringify({
+      type: 'RS256',
+      key: publicKey,
+      issuer: 'https://keycloak.example.com',
+      audience: 'aerie',
+    });
+    vi.stubEnv('HASURA_GRAPHQL_JWT_SECRET', jwtSecret);
+
+    // Token with correct issuer but wrong audience
+    const payload = createPayload({
+      iss: 'https://keycloak.example.com',
+      aud: 'wrong-audience',
+    });
+    const token = signToken(payload);
+
+    const result = await decodeJwt(`Bearer ${token}`);
+
+    expect(result.jwtPayload).toBeNull();
+    expect(result.jwtErrorMessage).toContain('jwt audience invalid');
+  });
+
+  test('skips issuer validation when not configured', async () => {
+    const jwtSecret = JSON.stringify({
+      type: 'RS256',
+      key: publicKey,
+      // no issuer configured
+    });
+    vi.stubEnv('HASURA_GRAPHQL_JWT_SECRET', jwtSecret);
+
+    const payload = createPayload({ iss: 'any-issuer' });
+    const token = signToken(payload);
+
+    const result = await decodeJwt(`Bearer ${token}`);
+
+    expect(result.jwtErrorMessage).toBe('');
+    expect(result.jwtPayload).not.toBeNull();
+  });
+
+  test('skips audience validation when not configured', async () => {
+    const jwtSecret = JSON.stringify({
+      type: 'RS256',
+      key: publicKey,
+      // no audience configured
+    });
+    vi.stubEnv('HASURA_GRAPHQL_JWT_SECRET', jwtSecret);
+
+    const payload = createPayload({ aud: 'any-audience' });
+    const token = signToken(payload);
+
+    const result = await decodeJwt(`Bearer ${token}`);
+
+    expect(result.jwtErrorMessage).toBe('');
+    expect(result.jwtPayload).not.toBeNull();
+  });
+
+  test('rejects expired token', async () => {
+    const jwtSecret = JSON.stringify({
+      type: 'RS256',
+      key: publicKey,
+    });
+    vi.stubEnv('HASURA_GRAPHQL_JWT_SECRET', jwtSecret);
+
+    const payload = createPayload();
+    const token = signToken(payload, { expiresIn: '-1h' }); // Already expired
+
+    const result = await decodeJwt(`Bearer ${token}`);
+
+    expect(result.jwtPayload).toBeNull();
+    expect(result.jwtErrorMessage).toContain('Token expired');
+  });
+
+  test('returns error when no key or jwk_url provided', async () => {
+    const jwtSecret = JSON.stringify({
+      type: 'RS256',
+      // no key or jwk_url
+    });
+    vi.stubEnv('HASURA_GRAPHQL_JWT_SECRET', jwtSecret);
+
+    const payload = createPayload();
+    const token = signToken(payload);
+
+    const result = await decodeJwt(`Bearer ${token}`);
+
+    expect(result.jwtPayload).toBeNull();
+    expect(result.jwtErrorMessage).toContain('Neither a valid JWT Key or JWK URL were provided');
+  });
+});
+
+describe('decodeJwt with HS256 static key', () => {
+  const hmacSecret = 'super-secret-key-that-is-long-enough-for-hs256';
+
+  beforeEach(() => {
+    vi.stubEnv('JWT_ALGORITHMS', JSON.stringify(['HS256']));
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test('successfully verifies valid token with HS256 static key', async () => {
+    const jwtSecret = JSON.stringify({
+      type: 'HS256',
+      key: hmacSecret,
+    });
+    vi.stubEnv('HASURA_GRAPHQL_JWT_SECRET', jwtSecret);
+
+    const payload = createPayload();
+    const token = jwt.sign(payload, hmacSecret, { algorithm: 'HS256', expiresIn: '1h' });
+
+    const result = await decodeJwt(`Bearer ${token}`);
+
+    expect(result.jwtErrorMessage).toBe('');
+    expect(result.jwtPayload).not.toBeNull();
+    expect(result.jwtPayload?.username).toBe('test-user');
+  });
+
+  test('rejects token signed with wrong key', async () => {
+    const jwtSecret = JSON.stringify({
+      type: 'HS256',
+      key: hmacSecret,
+    });
+    vi.stubEnv('HASURA_GRAPHQL_JWT_SECRET', jwtSecret);
+
+    const payload = createPayload();
+    const token = jwt.sign(payload, 'different-secret-key-for-signing', {
+      algorithm: 'HS256',
+      expiresIn: '1h',
+    });
+
+    const result = await decodeJwt(`Bearer ${token}`);
+
+    expect(result.jwtPayload).toBeNull();
+    expect(result.jwtErrorMessage).toContain('invalid signature');
+  });
+});

--- a/test/jwt.test.ts
+++ b/test/jwt.test.ts
@@ -389,3 +389,46 @@ describe('configurable JWT claim paths', () => {
     expect(namespace['roles']).toEqual(['aerie_admin', 'aerie_user']);
   });
 });
+
+describe('decodeJwt binds the accepted algorithm to the secret type', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test('verifies an HS256 token for an HS256 secret with no JWT_ALGORITHMS set (regression guard)', async () => {
+    // The regular (non-OIDC) test/CI phase sets no JWT_ALGORITHMS. The accepted algorithm must
+    // come from the secret's `type`, not the process-wide default (RS256) — otherwise the HS256
+    // tokens generateJwt mints get rejected (the failure that broke the HS256 e2e phase).
+    const hmacSecret = 'super-secret-key-that-is-long-enough-for-hs256';
+    vi.stubEnv('HASURA_GRAPHQL_JWT_SECRET', JSON.stringify({ type: 'HS256', key: hmacSecret }));
+
+    const token = jwt.sign(createPayload(), hmacSecret, { algorithm: 'HS256', expiresIn: '1h' });
+    const result = await decodeJwt(`Bearer ${token}`);
+
+    expect(result.jwtErrorMessage).toBe('');
+    expect(result.jwtPayload?.username).toBe('test-user');
+  });
+
+  test('verifies an RS256 token for an RS256 secret with no JWT_ALGORITHMS set', async () => {
+    vi.stubEnv('HASURA_GRAPHQL_JWT_SECRET', JSON.stringify({ type: 'RS256', key: publicKey }));
+
+    const result = await decodeJwt(`Bearer ${signToken(createPayload())}`);
+
+    expect(result.jwtErrorMessage).toBe('');
+    expect(result.jwtPayload).not.toBeNull();
+  });
+
+  test('rejects an HS256 token forged with the RSA public key on an RS256 secret, even if JWT_ALGORITHMS lists HS256', async () => {
+    // Classic RS256->HS256 confusion: the RSA public key is public, so an attacker can sign an
+    // HS256 token using it as the HMAC secret. Binding the accepted algorithm to the secret's
+    // declared type (RS256) rejects it regardless of a permissive/misconfigured JWT_ALGORITHMS.
+    vi.stubEnv('JWT_ALGORITHMS', JSON.stringify(['RS256', 'HS256'])); // deliberately permissive — must be ignored
+    vi.stubEnv('HASURA_GRAPHQL_JWT_SECRET', JSON.stringify({ type: 'RS256', key: publicKey }));
+
+    const forged = jwt.sign(createPayload(), publicKey, { algorithm: 'HS256', expiresIn: '1h' });
+    const result = await decodeJwt(`Bearer ${forged}`);
+
+    expect(result.jwtPayload).toBeNull();
+    expect(result.jwtErrorMessage).not.toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

Adds **JWKS / RS256 token verification** to the gateway so it can validate IdP-issued (OIDC) JWTs, alongside the existing gateway-signed HS256 tokens (JWT/SSO modes). In the OIDC flow, the UI calls the gateway's `/auth/session` endpoint to validate the token and provision first-time users – both require the gateway to verify tokens signed by an external IdP (e.g. Keycloak) whose public keys are published at a JWKS endpoint. Existing HS256 deployments are unaffected.

Companion PR: **plandev-ui** — https://github.com/NASA-AMMOS/aerie-ui/pull/1746 (browser-side OIDC: PKCE, token exchange, refresh, logout).

## What changed

- **JWKS verification (`decodeJwt`).** When `HASURA_GRAPHQL_JWT_SECRET` specifies a `jwk_url`, the gateway fetches the IdP's public signing key (by the token's `kid`) and verifies the signature. No secrets are shared with the IdP during this process. When it specifies a `key`, verification stays on the static HS256/RS256 key path as before. Signing keys are fetched through a **memoized, rate-limited JWKS client** (cached 24h, ≤10 IdP fetches/min), so keys are reused across requests rather than re-fetched on every session validation. This behavior is consistent with action-server and workspace-server.
- **Algorithm bound to the secret's declared `type`.** Verification now accepts *only* the algorithm declared in the secret (`HS256` **or** `RS256`), replacing the process-wide `JWT_ALGORITHMS` list. This makes each deployment self-configuring from its own secret and, critically, **prevents an RS256→HS256 algorithm-confusion forgery** (a JWKS/RS256 verifier will never accept an HS256 token signed with the public RSA key). `alg: none` is excluded for the same reason.
- **Optional `issuer` / `audience` validation.** Add `issuer` and/or `audience` to the secret to enforce the token's `iss`/`aud` claims on top of the signature — `iss` pins the token to your IdP/realm (defends against a sibling realm/tenant on a shared IdP), `aud` prevents a token minted for another client from being replayed against the gateway (`audience` accepts a string or an array of allowed values). Recommended for OIDC. Note: the gateway validates the **access** token, so the IdP must include the expected audience there — in Keycloak, via an Audience protocol mapper — otherwise requests 401 with "jwt audience invalid".
- **OIDC user provisioning in `session()`.** First-time OIDC users get a `permissions.users` row via a lazy upsert (direct SQL with elevated DB credentials – the same pattern JWT/SSO `login()` uses). For Keycloak-issued tokens this is the *only* place provisioning happens, since the UI's user-scoped JWT lacks Hasura insert permission. Provisioning failures are logged and non-fatal (a valid token still yields a valid session). **Note:** for an existing user this is a `SELECT` only — it does **not** update or prune roles. OIDC roles are authoritative in the JWT itself; a role revoked at the IdP takes effect on the next token, enforced by Hasura's `x-hasura-allowed-roles` check.
  **On roles / revocation (important):** for an *existing* user this call is a `SELECT` only — it does **not** update or prune roles (contrast CAM/SSO, which does a full `DELETE + upsert` via `syncRolesToDB`). That's intentional: **OIDC roles are authoritative in the JWT**, not the DB. When the IdP revokes a role, the *next* token omits it (refresh fires ~10s before `exp`, or on re-login) and Hasura enforces it per-request from `x-hasura-allowed-roles`; the UI role-switcher is likewise rebuilt from token claims. So revocation is effective on token rollover — **not instantly mid-session**. The DB's `allowed_roles` may go stale (never pruned in OIDC mode), which is harmless because nothing reads roles from the DB for an OIDC user — but worth knowing if that ever changes.

- **Configurable claim paths.** New `JWT_CLAIMS_*` env vars let deployments point at a non-default claims namespace / claim keys (defaults follow Hasura convention). Used consistently in `decodeJwt`, `session()`, `generateJwt`, and `adminOnlyAuth` middleware.
- **`decodeJwt` is now async** (JWKS lookup is async); callers (`session`, `adminOnlyAuth`, `/modelExtraction`) updated to `await`.

## Configuration

`HASURA_GRAPHQL_JWT_SECRET` now accepts a JSON object for OIDC/JWKS:

```json
{ "type": "RS256", "jwk_url": "https://your-idp/…/certs", "issuer": "https://your-idp/realms/aerie", "audience": "aerie" }
```

The IdP must emit the nested Hasura claims object (`https://hasura.io/jwt/claims` → `x-hasura-user-id`, `x-hasura-default-role` (string), `x-hasura-allowed-roles` (array)). The same secret is shared with Hasura, action-server, and workspace-server.

New / changed env vars (see `docs/ENVIRONMENT.md`):

| Var | Change |
|---|---|
| `HASURA_GRAPHQL_JWT_SECRET` | now also accepts `jwk_url` / `issuer` / `audience` (RS256/JWKS) |
| `JWT_CLAIMS_NAMESPACE` / `_USER_ID` / `_ALLOWED_ROLES` / `_DEFAULT_ROLE` | **new** — claim-path overrides (default to Hasura convention) |
| `JWT_ALGORITHMS` | **removed** — algorithm is derived from the secret's `type` |

## Backward compatibility

- JWT and SSO/CAM modes are unchanged; existing HS256 deployments keep working with no config change.
- **Breaking (config):** `JWT_ALGORITHMS` is removed; a leftover value is simply ignored (no startup error). Existing HS256/RS256 gateway deployments are unaffected — the algorithm is now taken from the secret's `type`, which already matched (signing already used `type`). Note the new behavior accepts a **single** algorithm (the secret's `type`): standard for HS256/RS256 and RS256-based OIDC, but an IdP signing with a non-`type` algorithm or rotating across multiple algorithms would need `type` set correctly (multi-algorithm acceptance is not supported — follow-up if needed). This narrowing is deliberate: it prevents the RS256→HS256 algorithm-confusion forgery and refuses `alg: none`.

## Testing

`test/jwt.test.ts` (new, ~430 lines) covers: Bearer-header parsing; RS256 static-key + HS256 static-key verify/reject; issuer & audience validation (match, mismatch, array-of-audiences, both-configured, skip-when-unset); expired-token rejection; missing key/jwk_url error; configurable claim paths (default namespace, custom namespace, Keycloak-style); and algorithm binding — including a **regression guard that an HS256 token forged with the RSA public key is rejected on an RS256 secret even if `HS256` were listed**.