### PR TITLE
Add "on conflict do nothing" when inserting into `users_allowed_roles`

### DIFF
--- a/src/packages/auth/functions.ts
+++ b/src/packages/auth/functions.ts
@@ -56,7 +56,7 @@ export async function getUserRoles(
     return { allowed_roles: hasura_allowed_roles, default_role: hasura_default_role };
   } else {
     // since user does not exist, this upsert is just an insert
-    upsertUserRoles(username, default_role, allowed_roles);
+    await upsertUserRoles(username, default_role, allowed_roles);
     return { allowed_roles, default_role };
   }
 }

--- a/src/packages/auth/functions.ts
+++ b/src/packages/auth/functions.ts
@@ -91,6 +91,7 @@ export async function upsertUserRoles(username: string, default_role: string, al
       `
         insert into permissions.users_allowed_roles (username, allowed_role)
         values ($1, $2)
+        on conflict (username, allowed_role) do nothing;
       `,
       [username, allowed_role],
     );


### PR DESCRIPTION
I noticed while investigating the [sequencing test failures ](https://github.com/NASA-AMMOS/aerie/issues/1636) that right before the sequencing server got a `EPIPE` error from the `/file` endpoint that the Gateway logged an error. 

<details>
<summary>Error Logs</summary>
Error in the sequencing server:
```
2025-09-03T20:58:43.1750315Z     FetchError: request to http://localhost:9000/file failed, reason: write EPIPE
```

Error in the Gateway half a second before that:
```
2025-09-03T20:58:42.674102822Z /app/node_modules/pg-pool/index.js:45
2025-09-03T20:58:42.674209732Z     Error.captureStackTrace(err);
2025-09-03T20:58:42.674219701Z           ^
2025-09-03T20:58:42.674224049Z 
2025-09-03T20:58:42.674227916Z error: duplicate key value violates unique constraint "users_allowed_roles_pkey"
2025-09-03T20:58:42.674231813Z     at /app/node_modules/pg-pool/index.js:45:11
2025-09-03T20:58:42.674235690Z     at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
2025-09-03T20:58:42.674239397Z     at async upsertUserRoles (file:///app/dist/packages/auth/functions.js:60:9) {
2025-09-03T20:58:42.674242784Z   length: 282,
2025-09-03T20:58:42.674246320Z   severity: 'ERROR',
2025-09-03T20:58:42.674250117Z   code: '23505',
2025-09-03T20:58:42.674253814Z   detail: 'Key (username, allowed_role)=(AerieE2ESequencingTests, ***_admin) already exists.',
2025-09-03T20:58:42.674257541Z   hint: undefined,
2025-09-03T20:58:42.674261328Z   position: undefined,
2025-09-03T20:58:42.674264785Z   internalPosition: undefined,
2025-09-03T20:58:42.674268401Z   internalQuery: undefined,
2025-09-03T20:58:42.674375251Z   where: undefined,
2025-09-03T20:58:42.674380651Z   schema: 'permissions',
2025-09-03T20:58:42.674384248Z   table: 'users_allowed_roles',
2025-09-03T20:58:42.674387654Z   column: undefined,
2025-09-03T20:58:42.674391381Z   dataType: undefined,
2025-09-03T20:58:42.674450441Z   constraint: 'users_allowed_roles_pkey',
2025-09-03T20:58:42.674456863Z   file: 'nbtinsert.c',
2025-09-03T20:58:42.674460740Z   line: '666',
2025-09-03T20:58:42.674464317Z   routine: '_bt_check_unique'
2025-09-03T20:58:42.674467773Z }
```
</details>

While I can't say for sure that the Gateway error is the root cause of the sequencing test error, it is at least straightforward to fix.

Summary: when `upsertUserRoles` attempts to upsert a role that the user already has, the DB returns with a `uniqueness violation`.  Adding an `on conflict do nothing` means that instead it will just not attempt to insert the duplicate row.

What's got me stumped, however, is trying to figure out _why_ this error is happening in the middle of the sequencing tests. This method is only called in one of two cases:

1) When a new user is added to the system (that is, we attempt to get the user's role information and get nothing)
2) When CAM SSO auth is syncing user roles after a change

My current theory is that this is a race condition caused by the sequencing tests a) not creating their test user (`AerieE2ESequencingTests`) during the global setup and b) running multiple tests in parallel. This would lead to two near-simultaneous `login` requests both not seeing the `AerieE2ESequencingTests` user and both then trying to create that user, which may explain why this happens a lot but not 100% of the time.

That doesn't explain why this isn't an issue with our JUnit tests unless either a) there's some setup code that I've both forgotten about and can't find or b) they're not running in parallel like they're supposed to (which, given the amount of time they take may be the case)