### PR TITLE
update Aerie -> PlanDev in README and user-facing strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,26 @@
 
 # aerie-gateway
 
-The API gateway for [Aerie](https://github.com/NASA-AMMOS/aerie).
+The API gateway for [PlanDev](https://github.com/NASA-AMMOS/aerie).
+
+## Aerie -> PlanDev Rebrand
+
+This product was **formerly known as Aerie and is now named PlanDev**. While we've updated most documentation and external references, some legacy mentions of the old product name may remain as we complete the transition.
+
+What to know:
+
+* The planning product, including modeling, simulation, scheduling and constraint-checking, is now named PlanDev
+* The sequencing product, including the sequence editor, workspaces, and actions, is now named SeqDev
+* All features and functionality remain the same
+* Currently, repository names, package names and other internal code references will retain their existing names, and deployment/migration procedures have not changed
+* In a future release, our repository and/or package names may change. If so, this will be communicated to users via release notes and normal communication channels
+
+For the latest documentation, visit: [PlanDev Documentation](https://nasa-ammos.github.io/plandev-docs/)
 
 ## Need Help?
 
-- Join us on the [NASA-AMMOS Slack](https://join.slack.com/t/nasa-ammos/shared_invite/zt-1mlgmk5c2-MgqVSyKzVRUWrXy87FNqPw) (#aerie-users)
-- Contact aerie-support@googlegroups.com
+- Join us on the [NASA-AMMOS Slack](https://join.slack.com/t/nasa-ammos/shared_invite/zt-1mlgmk5c2-MgqVSyKzVRUWrXy87FNqPw) (#plandev-users)
+- Contact plandev-support@googlegroups.com
 
 ## Develop
 
@@ -23,7 +37,7 @@ npm run dev
 
 This will watch for code changes and rebuild and restart the gateway server automatically.
 
-If you are running Aerie Gateway within a container (i.e. the docker-compose from the main Aerie repo), run the following before starting the container:
+If you are running PlanDev Gateway within a container (i.e. the docker-compose from the main PlanDev repo), run the following before starting the container:
 
 ```sh
 npm install

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,1 +1,1 @@
-To report vulnerabilities in Aerie, please email us at aerie_support@jpl.nasa.gov.
+To report vulnerabilities in PlanDev, please email us at plandev_support@jpl.nasa.gov.

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -2,33 +2,33 @@
 
 This document provides detailed information about environment variables for the gateway.
 
-| Name                        | Description                                                                                          | Type     | Default                                        |
-| --------------------------- |------------------------------------------------------------------------------------------------------| -------- | ---------------------------------------------- |
-| `ALLOWED_ROLES`             | Allowed roles when authentication is enabled.                                                        | `array`  | ["user", "viewer"]                             |
-| `ALLOWED_ROLES_NO_AUTH`     | Allowed roles when authentication is disabled.                                                       | `array`  | ["aerie_admin", "user", "viewer"]              |
-| `AUTH_GROUP_ROLE_MAPPINGS`  | JSON object that maps auth provider groups to Aerie roles. See [SSO authentication docs][SSO authn]  | `JSON`   | {}                                             |
-| `AUTH_TYPE`                 | Mode of authentication. Set to `cam` to enable CAM authentication.                                   | `string` | none                                           |
-| `AUTH_URL`                  | URL of Auth provider's REST API. Used if the given `AUTH_TYPE` is not set to `none`.                 | `string` | https://atb-ocio-12b.jpl.nasa.gov:8443/cam-api |
-| `AUTH_UI_URL`               | URL of Auth provider's login UI. Returned to the UI if SSO token is invalid, so user is redirected   | `string` | https://atb-ocio-12b.jpl.nasa.gov:8443/cam-ui  |
-| `AUTH_SSO_TOKEN_NAME`       | The name of the SSO tokens the Gateway should parse cookies for. Likely found in auth provider docs. | `array`  | ["iPlanetDirectoryPro"]                        |
-| `DEFAULT_ROLE`              | Default roles when authentication is enabled. See [SSO authorization docs][SSO authz] for details.   | `array`  | ["user"]                                       |
-| `DEFAULT_ROLE_NO_AUTH`      | Default role when authentication is disabled.                                                        | `string` | aerie_admin                                    |
-| `GQL_API_URL`               | URL of GraphQL API for the GraphQL Playground.                                                       | `string` | http://localhost:8080/v1/graphql               |
-| `GQL_API_WS_URL`            | URL of GraphQL WebSocket API for the GraphQL Playground.                                             | `string` | ws://localhost:8080/v1/graphql                 |
-| `HASURA_API_URL`            | URL of the base Hasura API.                                                                          | `string` | http://hasura:8080/                            |
-| `HASURA_GRAPHQL_JWT_SECRET` | The JWT secret. Also in Hasura. **Required** even if auth off in Hasura.                             | `string` |                                                |
-| `JWT_ALGORITHMS`            | List of [JWT signing algorithms][algorithms]. Must include algorithm in `HASURA_GRAPHQL_JWT_SECRET`. | `array`  | ["HS256"]                                      |
-| `JWT_EXPIRATION`            | Amount of time until JWT expires.                                                                    | `string` | 36h                                            |
-| `LOG_FILE`                  | Either an output filepath to log to, or 'console'.                                                   | `string` | console                                        |
-| `LOG_LEVEL`                 | Logging level for filtering logs.                                                                    | `string` | warn                                           |
-| `PORT`                      | Port the Gateway server listens on.                                                                  | `number` | 9000                                           |
-| `AERIE_DB_HOST`             | Hostname of the Aerie Posgres Database.                                                              | `string` | localhost                                      |
-| `AERIE_DB_PORT`             | Port of the Aerie Posgres Database.                                                                  | `number` | 5432                                           |
-| `GATEWAY_DB_USER`           | Username of the Gateway DB User.                                                                     | `string` |                                                |
-| `GATEWAY_DB_PASSWORD`       | Password of the Gateway DB User.                                                                     | `string` |                                                |
-| `RATE_LIMITER_FILES_MAX`    | Max requests allowed every 15 minutes to file endpoints                                              | `number` | 1000                                           |
-| `RATE_LIMITER_LOGIN_MAX`    | Max requests allowed every 15 minutes to login endpoints                                             | `number` | 1000                                           |
+| Name                        | Description                                                                                           | Type     | Default                                        |
+| --------------------------- |-------------------------------------------------------------------------------------------------------| -------- | ---------------------------------------------- |
+| `ALLOWED_ROLES`             | Allowed roles when authentication is enabled.                                                         | `array`  | ["user", "viewer"]                             |
+| `ALLOWED_ROLES_NO_AUTH`     | Allowed roles when authentication is disabled.                                                        | `array`  | ["aerie_admin", "user", "viewer"]              |
+| `AUTH_GROUP_ROLE_MAPPINGS`  | JSON object that maps auth provider groups to PlanDev roles. See [SSO authentication docs][SSO authn] | `JSON`   | {}                                             |
+| `AUTH_TYPE`                 | Mode of authentication. Set to `cam` to enable CAM authentication.                                    | `string` | none                                           |
+| `AUTH_URL`                  | URL of Auth provider's REST API. Used if the given `AUTH_TYPE` is not set to `none`.                  | `string` | https://atb-ocio-12b.jpl.nasa.gov:8443/cam-api |
+| `AUTH_UI_URL`               | URL of Auth provider's login UI. Returned to the UI if SSO token is invalid, so user is redirected    | `string` | https://atb-ocio-12b.jpl.nasa.gov:8443/cam-ui  |
+| `AUTH_SSO_TOKEN_NAME`       | The name of the SSO tokens the Gateway should parse cookies for. Likely found in auth provider docs.  | `array`  | ["iPlanetDirectoryPro"]                        |
+| `DEFAULT_ROLE`              | Default roles when authentication is enabled. See [SSO authorization docs][SSO authz] for details.    | `array`  | ["user"]                                       |
+| `DEFAULT_ROLE_NO_AUTH`      | Default role when authentication is disabled.                                                         | `string` | aerie_admin                                    |
+| `GQL_API_URL`               | URL of GraphQL API for the GraphQL Playground.                                                        | `string` | http://localhost:8080/v1/graphql               |
+| `GQL_API_WS_URL`            | URL of GraphQL WebSocket API for the GraphQL Playground.                                              | `string` | ws://localhost:8080/v1/graphql                 |
+| `HASURA_API_URL`            | URL of the base Hasura API.                                                                           | `string` | http://hasura:8080/                            |
+| `HASURA_GRAPHQL_JWT_SECRET` | The JWT secret. Also in Hasura. **Required** even if auth off in Hasura.                              | `string` |                                                |
+| `JWT_ALGORITHMS`            | List of [JWT signing algorithms][algorithms]. Must include algorithm in `HASURA_GRAPHQL_JWT_SECRET`.  | `array`  | ["HS256"]                                      |
+| `JWT_EXPIRATION`            | Amount of time until JWT expires.                                                                     | `string` | 36h                                            |
+| `LOG_FILE`                  | Either an output filepath to log to, or 'console'.                                                    | `string` | console                                        |
+| `LOG_LEVEL`                 | Logging level for filtering logs.                                                                     | `string` | warn                                           |
+| `PORT`                      | Port the Gateway server listens on.                                                                   | `number` | 9000                                           |
+| `AERIE_DB_HOST`             | Hostname of the PlanDev Posgres Database.                                                               | `string` | localhost                                      |
+| `AERIE_DB_PORT`             | Port of the PlanDev Posgres Database.                                                                   | `number` | 5432                                           |
+| `GATEWAY_DB_USER`           | Username of the Gateway DB User.                                                                      | `string` |                                                |
+| `GATEWAY_DB_PASSWORD`       | Password of the Gateway DB User.                                                                      | `string` |                                                |
+| `RATE_LIMITER_FILES_MAX`    | Max requests allowed every 15 minutes to file endpoints                                               | `number` | 1000                                           |
+| `RATE_LIMITER_LOGIN_MAX`    | Max requests allowed every 15 minutes to login endpoints                                              | `number` | 1000                                           |
 
 [algorithms]: https://github.com/auth0/node-jsonwebtoken#algorithms-supported
-[SSO authn]: https://nasa-ammos.github.io/aerie-docs/deployment/advanced-authentication
-[SSO authz]: https://nasa-ammos.github.io/aerie-docs/deployment/advanced-permissions
+[SSO authn]: https://nasa-ammos.github.io/plandev-docs/deployment/advanced-authentication
+[SSO authz]: https://nasa-ammos.github.io/plandev-docs/deployment/advanced-permissions

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,6 +1,6 @@
 # Release
 
-This document contains instructions on how to release the Aerie Gateway.
+This document contains instructions on how to release the PlanDev Gateway.
 
 ## Steps
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aerie-gateway",
-  "description": "The API gateway for Aerie.",
+  "description": "The API gateway for PlanDev.",
   "version": "3.8.1",
   "type": "module",
   "license": "MIT",

--- a/src/packages/health/health.ts
+++ b/src/packages/health/health.ts
@@ -45,7 +45,7 @@ export default (app: Express) => {
    *             schema:
    *                properties:
    *                  gateway_version:
-   *                    description: The current version of the Aerie Gateway.
+   *                    description: The current version of the PlanDev Gateway.
    *                    type: string
    *     summary: Get the current version of the Gateway and Database Schema
    *     tags:

--- a/src/packages/swagger/swagger.ts
+++ b/src/packages/swagger/swagger.ts
@@ -18,7 +18,7 @@ const options: swaggerJsDoc.Options = {
       },
     },
     info: {
-      title: 'Aerie Gateway',
+      title: 'PlanDev Gateway',
       version: VERSION,
     },
     openapi: '3.0.0',
@@ -46,7 +46,7 @@ export default async (app: Express) => {
     swagger.serve,
     swagger.setup(spec, {
       customCss: '.swagger-ui .topbar { display: none }',
-      customSiteTitle: 'Aerie Gateway',
+      customSiteTitle: 'PlanDev Gateway',
     }),
   );
 };


### PR DESCRIPTION
See https://nasa-ammos.github.io/plandev-docs/introduction/ for info on rebranding effort. Don't merge until PlanDev v3.9.0 release.