### PR TITLE
Add /uploadActivities

### DIFF
--- a/src/packages/plan/plan.ts
+++ b/src/packages/plan/plan.ts
@@ -246,36 +246,7 @@ async function importPlan(req: Request, res: Response) {
         );
 
         const activityRemap: Record<number, number> = {};
-        const activityDirectivesInsertInput = activities.map(
-          ({
-            anchored_to_start: anchoredToStart,
-            arguments: activityArguments,
-            metadata,
-            name: activityName,
-            start_offset: startOffset,
-            tags,
-            type,
-          }) => {
-            const activityDirectiveInsertInput: ActivityDirectiveInsertInput = {
-              anchor_id: null,
-              anchored_to_start: anchoredToStart,
-              arguments: activityArguments,
-              metadata,
-              name: activityName,
-              plan_id: (createdPlan as PlanSchema).id,
-              start_offset: startOffset,
-              tags: {
-                data:
-                  tags?.map(({ tag: { name } }) => ({
-                    tag_id: tagsMap[name].id,
-                  })) ?? [],
-              },
-              type,
-            };
-
-            return activityDirectiveInsertInput;
-          },
-        );
+        const activityDirectivesInsertInput = remapActivities(activities, (createdPlan as PlanSchema).id, tagsMap);
 
         const createdActivitiesResponse = await fetch(GQL_API_URL, {
           body: JSON.stringify({
@@ -475,7 +446,7 @@ async function uploadActivities(req: Request, res: Response) {
 
     logger.info(`POST /uploadActivities: Uploaded activities`);
 
-    res.json(activities);
+    res.json(activities.length);
   } catch (error) {
     logger.error(`POST /uploadActivities: Error occurred during activity upload`);
     logger.error(error);

--- a/src/packages/plan/plan.ts
+++ b/src/packages/plan/plan.ts
@@ -54,7 +54,7 @@ async function createActivities(
   activities: ActivityDirectiveInsertInput[],
   activitiesJSON: ActivitiesJSON,
   planId: number,
-  headers: Record<string, string>
+  headers: Record<string, string>,
 ): Promise<number> {
   const activityRemap: Record<number, number> = {};
 

--- a/src/packages/plan/plan.ts
+++ b/src/packages/plan/plan.ts
@@ -202,7 +202,9 @@ async function importPlan(req: Request, res: Response) {
   };
 
   let createdPlan: PlanSchema | null = null;
-  const createdTags: Tag[] = [];
+
+  let createdTags: Tag[] = [];
+  let tagsMap: Record<string, Tag>;
 
   try {
     const { activities, simulation_arguments }: PlanTransfer = await parseJSONFile<PlanTransfer>(file);
@@ -250,7 +252,9 @@ async function importPlan(req: Request, res: Response) {
         // insert all the imported activities into the plan
         logger.info(`POST /importPlan: Importing activities: ${name}`);
 
-        const { createdTags, tagsMap } = await createTags(activities, headers as Record<string, string>);
+        const tagData = await createTags(activities, headers as Record<string, string>);
+        createdTags = tagData.createdTags;
+        tagsMap = tagData.tagsMap;
 
         const activityRemap: Record<number, number> = {};
         const activityDirectivesInsertInput = await remapActivities(activities, (createdPlan as PlanSchema).id, tagsMap);
@@ -388,12 +392,17 @@ async function uploadActivities(req: Request, res: Response) {
     'x-hasura-user-id': userHeader ? `${userHeader}` : '',
   }
 
-  const createdTags: Tag[] = [];
+  let createdTags: Tag[] = [];
+  let tagsMap: Record<string, Tag>;
 
   try {
     const { activities: activitiesJSON }: PlanTransfer = await parseJSONFile<PlanTransfer>(file);  // Activites upload is a subset of plan import
 
-    const { createdTags, tagsMap } = await createTags(activitiesJSON, headers as Record<string, string>);
+    // const { createdTags: createdTags, tagsMap } = await createTags(activitiesJSON, headers as Record<string, string>);
+    const tagData = await createTags(activitiesJSON, headers as Record<string, string>);
+    createdTags = tagData.createdTags;
+    tagsMap = tagData.tagsMap;
+
     const activityRemap: Record<number, number> = {};
 
     const activities = await remapActivities(activitiesJSON, parseInt(planIdString), tagsMap);

--- a/src/packages/plan/plan.ts
+++ b/src/packages/plan/plan.ts
@@ -24,7 +24,7 @@ import {
   ProfileSegment,
   ProfileSet,
   ProfileSets,
-  uploadActivitiesPayload,
+  UploadActivitiesPayload,
   UploadPlanDatasetJSON,
   UploadPlanDatasetPayload,
 } from '../../types/dataset.js';
@@ -393,7 +393,7 @@ async function uploadActivities(req: Request, res: Response) {
   } = req;
 
   const { body, file } = req;
-  const { plan_id: planIdString } = body as uploadActivitiesPayload;
+  const { plan_id: planIdString } = body as UploadActivitiesPayload;
 
   logger.info(`POST /uploadActivities: Uploading activities`);
 

--- a/src/packages/plan/plan.ts
+++ b/src/packages/plan/plan.ts
@@ -50,6 +50,96 @@ const refreshLimiter = rateLimit({
 
 const timeColumnKey = 'time_utc';
 
+async function createTags(activities: ActivitiesJSON, headers: Record<string, string>): Promise<{ createdTags: Tag[], tagsMap: Record<string, Tag> }> {
+  let createdTags: Tag[] = [];
+  const tagsResponse = await fetch(GQL_API_URL, {
+    body: JSON.stringify({
+      query: gql.GET_TAGS,
+    }),
+    headers,
+    method: 'POST',
+  });
+
+  const tagsResponseJSON = (await tagsResponse.json()) as {
+    data: {
+      tags: Tag[];
+    };
+  };
+
+  let tagsMap: Record<string, Tag> = {};
+  if (tagsResponseJSON != null && tagsResponseJSON.data != null) {
+    const {
+      data: { tags },
+    } = tagsResponseJSON;
+    tagsMap = tags.reduce((prevTagsMap: Record<string, Tag>, tag) => {
+      return {
+        ...prevTagsMap,
+        [tag.name]: tag,
+      };
+    }, {});
+  }
+
+  // derive a map of uniquely named tags from the list of activities that doesn't already exist in the database
+  const activityTags = activities.reduce(
+    (prevActivitiesTagsMap: Record<string, Pick<Tag, 'color' | 'name'>>, { tags }) => {
+      const currentTagsMap =
+        tags?.reduce(
+          (prevTagsMap: Record<string, Pick<Tag, 'color' | 'name'>>, { tag: { name: tagName, color } }) => {
+            // If the tag doesn't exist already, add it
+            if (tagsMap[tagName] === undefined) {
+              return {
+                ...prevTagsMap,
+                [tagName]: {
+                  color,
+                  name: tagName,
+                },
+              };
+            }
+            return prevTagsMap;
+          },
+          {},
+        ) ?? {};
+
+      return {
+        ...prevActivitiesTagsMap,
+        ...currentTagsMap,
+      };
+    },
+    {},
+  );
+
+  const createdTagsResponse = await fetch(GQL_API_URL, {
+    body: JSON.stringify({
+      query: gql.CREATE_TAGS,
+      variables: { tags: Object.values(activityTags) },
+    }),
+    headers,
+    method: 'POST',
+  });
+
+  const { data } = (await createdTagsResponse.json()) as {
+    data: {
+      insert_tags: { returning: Tag[] };
+    };
+  };
+
+  if (data && data.insert_tags && data.insert_tags.returning.length) {
+    // track the newly created tags for cleanup if an error occurs during plan import
+    createdTags = data.insert_tags.returning;
+  }
+
+  // add the newly created tags to the `tagsMap`
+  tagsMap = createdTags.reduce(
+    (prevTagsMap: Record<string, Tag>, tag) => ({
+      ...prevTagsMap,
+      [tag.name]: tag,
+    }),
+    tagsMap,
+  );
+
+  return { createdTags, tagsMap };
+}
+
 async function remapActivities(activities: ActivitiesJSON, planId: number, tagsMap: Record<string, Tag>) {
   return activities.map(
     ({
@@ -112,7 +202,7 @@ async function importPlan(req: Request, res: Response) {
   };
 
   let createdPlan: PlanSchema | null = null;
-  let createdTags: Tag[] = [];
+  const createdTags: Tag[] = [];
 
   try {
     const { activities, simulation_arguments }: PlanTransfer = await parseJSONFile<PlanTransfer>(file);
@@ -160,93 +250,10 @@ async function importPlan(req: Request, res: Response) {
         // insert all the imported activities into the plan
         logger.info(`POST /importPlan: Importing activities: ${name}`);
 
-        const tagsResponse = await fetch(GQL_API_URL, {
-          body: JSON.stringify({
-            query: gql.GET_TAGS,
-          }),
-          headers,
-          method: 'POST',
-        });
-
-        const tagsResponseJSON = (await tagsResponse.json()) as {
-          data: {
-            tags: Tag[];
-          };
-        };
-
-        let tagsMap: Record<string, Tag> = {};
-        if (tagsResponseJSON != null && tagsResponseJSON.data != null) {
-          const {
-            data: { tags },
-          } = tagsResponseJSON;
-          tagsMap = tags.reduce((prevTagsMap: Record<string, Tag>, tag) => {
-            return {
-              ...prevTagsMap,
-              [tag.name]: tag,
-            };
-          }, {});
-        }
-
-        // derive a map of uniquely named tags from the list of activities that doesn't already exist in the database
-        const activityTags = activities.reduce(
-          (prevActivitiesTagsMap: Record<string, Pick<Tag, 'color' | 'name'>>, { tags }) => {
-            const currentTagsMap =
-              tags?.reduce(
-                (prevTagsMap: Record<string, Pick<Tag, 'color' | 'name'>>, { tag: { name: tagName, color } }) => {
-                  // If the tag doesn't exist already, add it
-                  if (tagsMap[tagName] === undefined) {
-                    return {
-                      ...prevTagsMap,
-                      [tagName]: {
-                        color,
-                        name: tagName,
-                      },
-                    };
-                  }
-                  return prevTagsMap;
-                },
-                {},
-              ) ?? {};
-
-            return {
-              ...prevActivitiesTagsMap,
-              ...currentTagsMap,
-            };
-          },
-          {},
-        );
-
-        const createdTagsResponse = await fetch(GQL_API_URL, {
-          body: JSON.stringify({
-            query: gql.CREATE_TAGS,
-            variables: { tags: Object.values(activityTags) },
-          }),
-          headers,
-          method: 'POST',
-        });
-
-        const { data } = (await createdTagsResponse.json()) as {
-          data: {
-            insert_tags: { returning: Tag[] };
-          };
-        };
-
-        if (data && data.insert_tags && data.insert_tags.returning.length) {
-          // track the newly created tags for cleanup if an error occurs during plan import
-          createdTags = data.insert_tags.returning;
-        }
-
-        // add the newly created tags to the `tagsMap`
-        tagsMap = createdTags.reduce(
-          (prevTagsMap: Record<string, Tag>, tag) => ({
-            ...prevTagsMap,
-            [tag.name]: tag,
-          }),
-          tagsMap,
-        );
+        const { createdTags, tagsMap } = await createTags(activities, headers as Record<string, string>);
 
         const activityRemap: Record<number, number> = {};
-        const activityDirectivesInsertInput = remapActivities(activities, (createdPlan as PlanSchema).id, tagsMap);
+        const activityDirectivesInsertInput = await remapActivities(activities, (createdPlan as PlanSchema).id, tagsMap);
 
         const createdActivitiesResponse = await fetch(GQL_API_URL, {
           body: JSON.stringify({
@@ -288,12 +295,7 @@ async function importPlan(req: Request, res: Response) {
         // remap all the anchor ids to the newly created activity directives
         logger.info(`POST /importPlan: Re-assigning anchors: ${name}`);
 
-        const activityDirectivesSetInput = activities
-          .filter(({ anchor_id: anchorId }) => anchorId !== null)
-          .map(({ anchor_id: anchorId, id }) => ({
-            _set: { anchor_id: activityRemap[anchorId as number] },
-            where: { id: { _eq: activityRemap[id] }, plan_id: { _eq: (createdPlan as PlanSchema).id } },
-          }));
+        const activityDirectivesSetInput = await remapAnchors(activities, activityRemap, (createdPlan as PlanSchema).id);
 
         await fetch(GQL_API_URL, {
           body: JSON.stringify({
@@ -386,11 +388,15 @@ async function uploadActivities(req: Request, res: Response) {
     'x-hasura-user-id': userHeader ? `${userHeader}` : '',
   }
 
+  const createdTags: Tag[] = [];
+
   try {
     const { activities: activitiesJSON }: PlanTransfer = await parseJSONFile<PlanTransfer>(file);  // Activites upload is a subset of plan import
+
+    const { createdTags, tagsMap } = await createTags(activitiesJSON, headers as Record<string, string>);
     const activityRemap: Record<number, number> = {};
 
-    const activities = await remapActivities(activitiesJSON, parseInt(planIdString), {});
+    const activities = await remapActivities(activitiesJSON, parseInt(planIdString), tagsMap);
 
     const createdActivitiesResponse = await fetch(GQL_API_URL, {
       body: JSON.stringify({
@@ -431,7 +437,7 @@ async function uploadActivities(req: Request, res: Response) {
     // remap all the anchor ids to the newly created activity directives
     logger.info(`POST /uploadActivities: Re-assigning anchors`);
 
-    const activityDirectivesSetInput = remapAnchors(activitiesJSON, activityRemap, parseInt(planIdString));
+    const activityDirectivesSetInput = await remapAnchors(activitiesJSON, activityRemap, parseInt(planIdString));
 
     await fetch(GQL_API_URL, {
       body: JSON.stringify({
@@ -448,6 +454,14 @@ async function uploadActivities(req: Request, res: Response) {
 
     res.json(activities.length);
   } catch (error) {
+    // TODO: Handle cleanup on fail, need to delete tags if they were created
+    if (createdTags !== undefined && createdTags.length) {
+      await fetch(GQL_API_URL, {
+        body: JSON.stringify({ query: gql.DELETE_TAGS, variables: { tagIds: createdTags.map(({ id }) => id) } }),
+        headers,
+        method: 'POST',
+      });
+    }
     logger.error(`POST /uploadActivities: Error occurred during activity upload`);
     logger.error(error);
     res.status(500);

--- a/src/packages/plan/plan.ts
+++ b/src/packages/plan/plan.ts
@@ -10,6 +10,7 @@ import { parseJSONFile } from '../../util/fileParser.js';
 import { convertDateToDoy, getTimeDifference } from '../../util/time.js';
 import { HasuraError } from '../../types/hasura.js';
 import type {
+  ActivitiesJSON,
   ActivityDirective,
   ActivityDirectiveInsertInput,
   ImportPlanPayload,
@@ -23,6 +24,7 @@ import {
   ProfileSegment,
   ProfileSet,
   ProfileSets,
+  uploadActivitiesPayload,
   UploadPlanDatasetJSON,
   UploadPlanDatasetPayload,
 } from '../../types/dataset.js';
@@ -47,6 +49,48 @@ const refreshLimiter = rateLimit({
 });
 
 const timeColumnKey = 'time_utc';
+
+async function remapActivities(activities: ActivitiesJSON, planId: number, tagsMap: Record<string, Tag>) {
+  return activities.map(
+    ({
+      anchored_to_start: anchoredToStart,
+      arguments: activityArguments,
+      metadata,
+      name: activityName,
+      start_offset: startOffset,
+      tags,
+      type,
+    }) => {
+      const activityDirectiveInsertInput: ActivityDirectiveInsertInput = {
+        anchor_id: null,
+        anchored_to_start: anchoredToStart,
+        arguments: activityArguments,
+        metadata,
+        name: activityName,
+        plan_id: planId,
+        start_offset: startOffset,
+        tags: {
+          data:
+            tags?.map(({ tag: { name } }) => ({
+              tag_id: tagsMap[name].id,
+            })) ?? [],
+        },
+        type,
+      };
+
+      return activityDirectiveInsertInput;
+    },
+  );
+}
+
+async function remapAnchors(activities: ActivitiesJSON, activityRemap: Record<number, number>, planId: number) {
+  return activities
+    .filter(({ anchor_id: anchorId }) => anchorId !== null)
+    .map(({ anchor_id: anchorId, id }) => ({
+      _set: { anchor_id: activityRemap[anchorId as number] },
+      where: { id: { _eq: activityRemap[id] }, plan_id: { _eq: planId } },
+    }));
+}
 
 async function importPlan(req: Request, res: Response) {
   const authorizationHeader = req.get('authorization');
@@ -350,6 +394,94 @@ function profileHasSegments(profileSets: ProfileSets): boolean {
 
 function getSegmentByteSize(segment: ProfileSegment): number {
   return Buffer.byteLength(JSON.stringify(segment));
+}
+
+async function uploadActivities(req: Request, res: Response) {
+  const authorizationHeader = req.get('authorization');
+
+  const {
+    headers: { 'x-hasura-role': roleHeader, 'x-hasura-user-id': userHeader },
+  } = req;
+
+  const { body, file } = req;
+  const { plan_id: planIdString } = body as uploadActivitiesPayload;
+
+  logger.info(`POST /uploadActivities: Uploading activities`);
+
+  const headers: HeadersInit = {
+    Authorization: authorizationHeader ?? '',
+    'Content-Type': 'application/json',
+    'x-hasura-role': roleHeader ? `${roleHeader}` : '',
+    'x-hasura-user-id': userHeader ? `${userHeader}` : '',
+  }
+
+  try {
+    const { activities: activitiesJSON }: PlanTransfer = await parseJSONFile<PlanTransfer>(file);  // Activites upload is a subset of plan import
+    const activityRemap: Record<number, number> = {};
+
+    const activities = await remapActivities(activitiesJSON, parseInt(planIdString), {});
+
+    const createdActivitiesResponse = await fetch(GQL_API_URL, {
+      body: JSON.stringify({
+        query: gql.CREATE_ACTIVITY_DIRECTIVES,
+        variables: {
+          activityDirectivesInsertInput: activities,
+        },
+      }),
+      headers,
+      method: 'POST',
+    });
+
+    const createdActivityDirectivesData = (await createdActivitiesResponse.json()) as {
+      data: {
+        insert_activity_directive: {
+          returning: ActivityDirective[];
+        };
+      };
+    } | null;
+
+    if (createdActivityDirectivesData) {
+      const {
+        data: {
+          insert_activity_directive: { returning: createdActivityDirectives },
+        },
+      } = createdActivityDirectivesData;
+
+      if (createdActivityDirectives.length === activities.length) {
+        createdActivityDirectives.forEach((createdActivityDirective, index) => {
+          const { id } = activitiesJSON[index];
+
+          activityRemap[id] = createdActivityDirective.id;
+        });
+      } else {
+        throw new Error('Activity insertion failed.');
+      }
+    }
+    // remap all the anchor ids to the newly created activity directives
+    logger.info(`POST /uploadActivities: Re-assigning anchors`);
+
+    const activityDirectivesSetInput = remapAnchors(activitiesJSON, activityRemap, parseInt(planIdString));
+
+    await fetch(GQL_API_URL, {
+      body: JSON.stringify({
+        query: gql.UPDATE_ACTIVITY_DIRECTIVES,
+        variables: {
+          updates: activityDirectivesSetInput,
+        },
+      }),
+      headers,
+      method: 'POST',
+    });
+
+    logger.info(`POST /uploadActivities: Uploaded activities`);
+
+    res.json(activities);
+  } catch (error) {
+    logger.error(`POST /uploadActivities: Error occurred during activity upload`);
+    logger.error(error);
+    res.status(500);
+    res.send((error as Error).message);
+  }
 }
 
 async function uploadDataset(req: Request, res: Response) {
@@ -714,4 +846,44 @@ export default (app: Express) => {
    *       - Hasura
    */
   app.post('/uploadDataset', upload.single('external_dataset'), refreshLimiter, auth, uploadDataset);
+
+  /**
+   * @swagger
+   * /uploadActivities:
+   *   post:
+   *     security:
+   *       - bearerAuth: []
+   *     consumes:
+   *       - multipart/form-data
+   *     produces:
+   *       - application/json
+   *     parameters:
+   *      - in: header
+   *        name: x-hasura-role
+   *        schema:
+   *          type: string
+   *          required: false
+   *     requestBody:
+   *       content:
+   *         multipart/form-data:
+   *          schema:
+   *            type: object
+   *            properties:
+   *              plan_id:
+   *                type: long
+   *              activity_file:
+   *                format: binary
+   *                type: string
+   *     responses:
+   *       200:
+   *         description: ImportResponse
+   *       403:
+   *         description: Unauthorized error
+   *       401:
+   *         description: Unauthenticated error
+   *     summary: Upload a JSON of activities to a plan
+   *     tags:
+   *       - Hasura
+   */
+    app.post('/uploadActivities', upload.single('activity_file'), refreshLimiter, auth, uploadActivities);
 };

--- a/src/packages/plan/plan.ts
+++ b/src/packages/plan/plan.ts
@@ -50,7 +50,74 @@ const refreshLimiter = rateLimit({
 
 const timeColumnKey = 'time_utc';
 
-async function createTags(activities: ActivitiesJSON, headers: Record<string, string>): Promise<{ createdTags: Tag[], tagsMap: Record<string, Tag> }> {
+async function createActivities(
+  activities: ActivityDirectiveInsertInput[],
+  activitiesJSON: ActivitiesJSON,
+  planId: number,
+  headers: Record<string, string>
+): Promise<number> {
+  const activityRemap: Record<number, number> = {};
+
+  const createdActivitiesResponse = await fetch(GQL_API_URL, {
+    body: JSON.stringify({
+      query: gql.CREATE_ACTIVITY_DIRECTIVES,
+      variables: {
+        activityDirectivesInsertInput: activities,
+      },
+    }),
+    headers,
+    method: 'POST',
+  });
+
+  const createdActivityDirectivesData = (await createdActivitiesResponse.json()) as {
+    data: {
+      insert_activity_directive: {
+        returning: ActivityDirective[];
+      };
+    };
+  } | null;
+
+  if (createdActivityDirectivesData) {
+    const {
+      data: {
+        insert_activity_directive: { returning: createdActivityDirectives },
+      },
+    } = createdActivityDirectivesData;
+
+    if (createdActivityDirectives.length === activities.length) {
+      createdActivityDirectives.forEach((createdActivityDirective, index) => {
+        const { id } = activitiesJSON[index];
+
+        activityRemap[id] = createdActivityDirective.id;
+      });
+    } else {
+      throw new Error('Activity insertion failed.');
+    }
+    // remap all the anchor ids to the newly created activity directives
+    logger.info(`POST /uploadActivities: Re-assigning anchors`);
+
+    const activityDirectivesSetInput = await remapAnchors(activitiesJSON, activityRemap, planId);
+
+    await fetch(GQL_API_URL, {
+      body: JSON.stringify({
+        query: gql.UPDATE_ACTIVITY_DIRECTIVES,
+        variables: {
+          updates: activityDirectivesSetInput,
+        },
+      }),
+      headers,
+      method: 'POST',
+    });
+
+    return activities.length;
+  }
+  return 0;
+}
+
+async function createTags(
+  activities: ActivitiesJSON,
+  headers: Record<string, string>,
+): Promise<{ createdTags: Tag[]; tagsMap: Record<string, Tag> }> {
   let createdTags: Tag[] = [];
   const tagsResponse = await fetch(GQL_API_URL, {
     body: JSON.stringify({
@@ -83,22 +150,19 @@ async function createTags(activities: ActivitiesJSON, headers: Record<string, st
   const activityTags = activities.reduce(
     (prevActivitiesTagsMap: Record<string, Pick<Tag, 'color' | 'name'>>, { tags }) => {
       const currentTagsMap =
-        tags?.reduce(
-          (prevTagsMap: Record<string, Pick<Tag, 'color' | 'name'>>, { tag: { name: tagName, color } }) => {
-            // If the tag doesn't exist already, add it
-            if (tagsMap[tagName] === undefined) {
-              return {
-                ...prevTagsMap,
-                [tagName]: {
-                  color,
-                  name: tagName,
-                },
-              };
-            }
-            return prevTagsMap;
-          },
-          {},
-        ) ?? {};
+        tags?.reduce((prevTagsMap: Record<string, Pick<Tag, 'color' | 'name'>>, { tag: { name: tagName, color } }) => {
+          // If the tag doesn't exist already, add it
+          if (tagsMap[tagName] === undefined) {
+            return {
+              ...prevTagsMap,
+              [tagName]: {
+                color,
+                name: tagName,
+              },
+            };
+          }
+          return prevTagsMap;
+        }, {}) ?? {};
 
       return {
         ...prevActivitiesTagsMap,
@@ -256,61 +320,9 @@ async function importPlan(req: Request, res: Response) {
         createdTags = tagData.createdTags;
         tagsMap = tagData.tagsMap;
 
-        const activityRemap: Record<number, number> = {};
-        const activityDirectivesInsertInput = await remapActivities(activities, (createdPlan as PlanSchema).id, tagsMap);
+        const activityDirectivesInsertInput = await remapActivities(activities, createdPlan.id, tagsMap);
 
-        const createdActivitiesResponse = await fetch(GQL_API_URL, {
-          body: JSON.stringify({
-            query: gql.CREATE_ACTIVITY_DIRECTIVES,
-            variables: {
-              activityDirectivesInsertInput,
-            },
-          }),
-          headers,
-          method: 'POST',
-        });
-
-        const createdActivityDirectivesData = (await createdActivitiesResponse.json()) as {
-          data: {
-            insert_activity_directive: {
-              returning: ActivityDirective[];
-            };
-          };
-        } | null;
-
-        if (createdActivityDirectivesData) {
-          const {
-            data: {
-              insert_activity_directive: { returning: createdActivityDirectives },
-            },
-          } = createdActivityDirectivesData;
-
-          if (createdActivityDirectives.length === activities.length) {
-            createdActivityDirectives.forEach((createdActivityDirective, index) => {
-              const { id } = activities[index];
-
-              activityRemap[id] = createdActivityDirective.id;
-            });
-          } else {
-            throw new Error('Activity insertion failed.');
-          }
-        }
-
-        // remap all the anchor ids to the newly created activity directives
-        logger.info(`POST /importPlan: Re-assigning anchors: ${name}`);
-
-        const activityDirectivesSetInput = await remapAnchors(activities, activityRemap, (createdPlan as PlanSchema).id);
-
-        await fetch(GQL_API_URL, {
-          body: JSON.stringify({
-            query: gql.UPDATE_ACTIVITY_DIRECTIVES,
-            variables: {
-              updates: activityDirectivesSetInput,
-            },
-          }),
-          headers,
-          method: 'POST',
-        });
+        await createActivities(activityDirectivesInsertInput, activities, (createdPlan as PlanSchema).id, headers);
 
         // associate the tags with the newly created plan
         logger.info(`POST /importPlan: Importing plan tags: ${name}`);
@@ -390,77 +402,25 @@ async function uploadActivities(req: Request, res: Response) {
     'Content-Type': 'application/json',
     'x-hasura-role': roleHeader ? `${roleHeader}` : '',
     'x-hasura-user-id': userHeader ? `${userHeader}` : '',
-  }
+  };
 
   let createdTags: Tag[] = [];
   let tagsMap: Record<string, Tag>;
 
   try {
-    const { activities: activitiesJSON }: PlanTransfer = await parseJSONFile<PlanTransfer>(file);  // Activites upload is a subset of plan import
+    const { activities: activitiesJSON }: PlanTransfer = await parseJSONFile<PlanTransfer>(file); // Activites upload is a subset of plan import
 
     const tagData = await createTags(activitiesJSON, headers as Record<string, string>);
     createdTags = tagData.createdTags;
     tagsMap = tagData.tagsMap;
 
-    const activityRemap: Record<number, number> = {};
-
     const activities = await remapActivities(activitiesJSON, parseInt(planIdString), tagsMap);
 
-    const createdActivitiesResponse = await fetch(GQL_API_URL, {
-      body: JSON.stringify({
-        query: gql.CREATE_ACTIVITY_DIRECTIVES,
-        variables: {
-          activityDirectivesInsertInput: activities,
-        },
-      }),
-      headers,
-      method: 'POST',
-    });
-
-    const createdActivityDirectivesData = (await createdActivitiesResponse.json()) as {
-      data: {
-        insert_activity_directive: {
-          returning: ActivityDirective[];
-        };
-      };
-    } | null;
-
-    if (createdActivityDirectivesData) {
-      const {
-        data: {
-          insert_activity_directive: { returning: createdActivityDirectives },
-        },
-      } = createdActivityDirectivesData;
-
-      if (createdActivityDirectives.length === activities.length) {
-        createdActivityDirectives.forEach((createdActivityDirective, index) => {
-          const { id } = activitiesJSON[index];
-
-          activityRemap[id] = createdActivityDirective.id;
-        });
-      } else {
-        throw new Error('Activity insertion failed.');
-      }
-    }
-    // remap all the anchor ids to the newly created activity directives
-    logger.info(`POST /uploadActivities: Re-assigning anchors`);
-
-    const activityDirectivesSetInput = await remapAnchors(activitiesJSON, activityRemap, parseInt(planIdString));
-
-    await fetch(GQL_API_URL, {
-      body: JSON.stringify({
-        query: gql.UPDATE_ACTIVITY_DIRECTIVES,
-        variables: {
-          updates: activityDirectivesSetInput,
-        },
-      }),
-      headers,
-      method: 'POST',
-    });
+    const activitiesCreated = await createActivities(activities, activitiesJSON, parseInt(planIdString), headers);
 
     logger.info(`POST /uploadActivities: Uploaded activities`);
 
-    res.json(activities.length);
+    res.json(activitiesCreated);
   } catch (error) {
     // TODO: Handle cleanup on fail, need to delete tags if they were created
     if (createdTags !== undefined && createdTags.length) {
@@ -878,5 +838,5 @@ export default (app: Express) => {
    *     tags:
    *       - Hasura
    */
-    app.post('/uploadActivities', upload.single('activity_file'), refreshLimiter, auth, uploadActivities);
+  app.post('/uploadActivities', upload.single('activity_file'), refreshLimiter, auth, uploadActivities);
 };

--- a/src/packages/plan/plan.ts
+++ b/src/packages/plan/plan.ts
@@ -398,7 +398,6 @@ async function uploadActivities(req: Request, res: Response) {
   try {
     const { activities: activitiesJSON }: PlanTransfer = await parseJSONFile<PlanTransfer>(file);  // Activites upload is a subset of plan import
 
-    // const { createdTags: createdTags, tagsMap } = await createTags(activitiesJSON, headers as Record<string, string>);
     const tagData = await createTags(activitiesJSON, headers as Record<string, string>);
     createdTags = tagData.createdTags;
     tagsMap = tagData.tagsMap;

--- a/src/types/dataset.ts
+++ b/src/types/dataset.ts
@@ -21,6 +21,6 @@ export type UploadPlanDatasetJSON = {
   profileSet: ProfileSets;
 };
 
-export type uploadActivitiesPayload = {
+export type UploadActivitiesPayload = {
   plan_id: string;
 };

--- a/src/types/dataset.ts
+++ b/src/types/dataset.ts
@@ -20,3 +20,7 @@ export type UploadPlanDatasetJSON = {
   datasetStart: string;
   profileSet: ProfileSets;
 };
+
+export type uploadActivitiesPayload = {
+  plan_id: string;
+};

--- a/src/types/plan.ts
+++ b/src/types/plan.ts
@@ -78,8 +78,8 @@ export type ActivityDirectiveInsertInput = {
 export type ActivityDirectiveSetInput = Pick<ActivityDirectiveInsertInput, 'anchor_id'>;
 
 export type ActivitiesJSON = Pick<
-ActivityDirective,
-'anchor_id' | 'anchored_to_start' | 'arguments' | 'id' | 'metadata' | 'name' | 'start_offset' | 'tags' | 'type'
+  ActivityDirective,
+  'anchor_id' | 'anchored_to_start' | 'arguments' | 'id' | 'metadata' | 'name' | 'start_offset' | 'tags' | 'type'
 >[];
 
 export type PlanTransfer = Pick<PlanSchema, 'id' | 'duration' | 'model_id' | 'name' | 'start_time'> & {

--- a/src/types/plan.ts
+++ b/src/types/plan.ts
@@ -77,11 +77,13 @@ export type ActivityDirectiveInsertInput = {
 };
 export type ActivityDirectiveSetInput = Pick<ActivityDirectiveInsertInput, 'anchor_id'>;
 
+export type ActivitiesJSON = Pick<
+ActivityDirective,
+'anchor_id' | 'anchored_to_start' | 'arguments' | 'id' | 'metadata' | 'name' | 'start_offset' | 'tags' | 'type'
+>[];
+
 export type PlanTransfer = Pick<PlanSchema, 'id' | 'duration' | 'model_id' | 'name' | 'start_time'> & {
-  activities: Pick<
-    ActivityDirective,
-    'anchor_id' | 'anchored_to_start' | 'arguments' | 'id' | 'metadata' | 'name' | 'start_offset' | 'tags' | 'type'
-  >[];
+  activities: ActivitiesJSON;
   end_time: string;
   simulation_arguments: ArgumentsMap;
   tags?: {


### PR DESCRIPTION
This PR adds the route `/uploadActivities` which allows uploading of a set of activities to a plan. The activities are expected in the plan JSON format. 

See UI pull-request: https://github.com/NASA-AMMOS/aerie-ui/pull/1843