### PR TITLE
pin trivy-action to commit hash for release 0.35.0 to avoid compromised versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,7 +59,8 @@ jobs:
           load: true
           tags: ${{ env.REGISTRY }}/nasa-ammos/aerie-gateway:${{ github.sha }}
       - name: Scan Docker image
-        uses: aquasecurity/trivy-action@master
+        # pinned to commit for v0.35.0 https://github.com/aquasecurity/trivy-action/releases/tag/v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
         with:
           image-ref: ${{ env.REGISTRY }}/nasa-ammos/aerie-gateway:${{ github.sha }}
           format: 'table'


### PR DESCRIPTION
For details, see this security advisory:

https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23

The `trivy-action` repository was temporarily compromised and malicious versions were pushed. The `master` version is now safe, but we were exposed to this during the compromise because we were not pinned to a specific version. Customers are not exposed to this vulnerability unless they fork our repository and try to run our CI actions.

We do not believe that any important secrets were exfiltrated, the main environment variables which it had access to were just for our temporary e2e testing environment and the canary testing environment. These will also be rotated.

More detailed report coming soon.