### PR TITLE
Add upload simulation dataset feature

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ RUN apk add --no-cache curl
 COPY . /app
 WORKDIR /app
 
+# Install dependencies and build
+RUN npm ci && npm run build
+
 # define health check for container: /health route will return 200 if healthy
 HEALTHCHECK --interval=2s --timeout=2s --start-period=2s --retries=15 \
   CMD /bin/sh -c 'curl -sf http://localhost:$PORT/health || exit 1'

--- a/src/packages/plan/gql.ts
+++ b/src/packages/plan/gql.ts
@@ -117,6 +117,13 @@ export default {
       }
     }
   `,
+  UPLOAD_SIMULATION_DATASET: `#graphql
+    mutation UploadSimulationDataset($planId: Int!, $simulationResults: SimulationResultsInput!) {
+      uploadSimulationDataset(planId: $planId, simulationResults: $simulationResults) {
+        simulationDatasetId
+      }
+    }
+  `,
   UPDATE_SIMULATION: `#graphql
     mutation InitialSimulationUpdate($plan_id: Int!, $simulation: simulation_set_input!) {
       update_simulation(where: {plan_id: {_eq: $plan_id}}, _set: $simulation) {

--- a/src/packages/plan/plan.ts
+++ b/src/packages/plan/plan.ts
@@ -707,6 +707,58 @@ async function uploadDataset(req: Request, res: Response) {
   }
 }
 
+async function uploadSimulationDataset(req: Request, res: Response) {
+  const authorizationHeader = req.get('authorization');
+
+  const {
+    headers: { 'x-hasura-role': roleHeader, 'x-hasura-user-id': userHeader },
+  } = req;
+
+  const { body, file } = req;
+  const { plan_id: planIdString } = body as { plan_id: string };
+
+  const headers: HeadersInit = {
+    Authorization: authorizationHeader ?? '',
+    'Content-Type': 'application/json',
+    'x-hasura-role': roleHeader ? `${roleHeader}` : '',
+    'x-hasura-user-id': userHeader ? `${userHeader}` : '',
+  };
+
+  try {
+    const planId: number = parseInt(planIdString);
+    const simulationResults = await parseJSONFile<object>(file);
+
+    logger.info(`POST /uploadSimulationDataset: Uploading simulation dataset for plan ${planId}`);
+
+    const response = await fetch(GQL_API_URL, {
+      body: JSON.stringify({
+        query: gql.UPLOAD_SIMULATION_DATASET,
+        variables: { planId, simulationResults },
+      }),
+      headers,
+      method: 'POST',
+    });
+
+    type UploadResponse = { data: { uploadSimulationDataset: { simulationDatasetId: number } | null } };
+    const jsonResponse = (await response.json()) as UploadResponse | HasuraError;
+
+    if ((jsonResponse as UploadResponse).data?.uploadSimulationDataset != null) {
+      const { simulationDatasetId } = (jsonResponse as UploadResponse).data.uploadSimulationDataset!;
+      logger.info(`POST /uploadSimulationDataset: Created simulation dataset ID=${simulationDatasetId}`);
+      res.json(simulationDatasetId);
+    } else if ((jsonResponse as HasuraError).errors) {
+      throw new Error(JSON.stringify((jsonResponse as HasuraError).errors));
+    } else {
+      throw new Error('Simulation dataset upload unsuccessful.');
+    }
+  } catch (error) {
+    logger.error(`POST /uploadSimulationDataset: Error occurred during simulation dataset upload`);
+    logger.error(error);
+    res.status(500);
+    res.send((error as Error).message);
+  }
+}
+
 export default (app: Express) => {
   /**
    * @swagger
@@ -799,6 +851,36 @@ export default (app: Express) => {
    *       - Hasura
    */
   app.post('/uploadDataset', upload.single('external_dataset'), refreshLimiter, auth, uploadDataset);
+
+  /**
+   * @swagger
+   * /uploadSimulationDataset:
+   *   post:
+   *     security:
+   *       - bearerAuth: []
+   *     consumes:
+   *       - multipart/form-data
+   *     produces:
+   *       - application/json
+   *     requestBody:
+   *       content:
+   *         multipart/form-data:
+   *          schema:
+   *            type: object
+   *            properties:
+   *              plan_id:
+   *                type: integer
+   *              simulation_results_file:
+   *                format: binary
+   *                type: string
+   *     responses:
+   *       200:
+   *         description: The ID of the created simulation dataset
+   *     summary: Upload a simulation results JSON file to a plan
+   *     tags:
+   *       - Hasura
+   */
+  app.post('/uploadSimulationDataset', upload.single('simulation_results_file'), refreshLimiter, auth, uploadSimulationDataset);
 
   /**
    * @swagger


### PR DESCRIPTION
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

___REQUIRES_AERIE_PR___="1852"
[NASA-AMMOS/plandev#1852](https://github.com/NASA-AMMOS/plandev/pull/1852)

## Description

> **Dependencies:** This PR requires a corresponding plandev backend PR (`uploadSimulationDataset` endpoint) and a plandev-ui PR (upload button) before the feature is accessible to end users.

Adds a multipart file upload endpoint to the gateway that accepts a simulation results JSON file and forwards it to Hasura as an `uploadSimulationDataset` mutation.

Changes:

- **`src/packages/plan/gql.ts`** — adds `UPLOAD_SIMULATION_DATASET` GraphQL mutation
- **`src/packages/plan/plan.ts`** — adds `uploadSimulationDataset(planId, file)` handler; reads the uploaded JSON file, parses it, and calls the Hasura mutation with `planId` and `simulationResults`; adds Swagger documentation for the route
- **`Dockerfile`** — adds `npm ci && npm run build` step so the image builds the gateway before running it

Usage:

```
POST /uploadSimulationDataset
Content-Type: multipart/form-data

simulation_results_file: <simulation_results.json>
plan_id: <int>
```

Returns the created `simulationDatasetId` on success.

## Verification

Manually tested against a running PlanDev instance. No automated tests added (consistent with the existing gateway test strategy).

## Documentation

No existing documentation covers this endpoint. The Swagger spec is updated inline in `plan.ts`.

## Future work

- plandev-ui changes (separate PR) are required to expose this to end users via the UI